### PR TITLE
feat: add English localization with in-app language switcher

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,8 +15,8 @@ android {
         applicationId = "io.mo.glassmic"
         minSdk = 29
         targetSdk = 35
-        versionCode = 10
-        versionName = "1.2.8"
+        versionCode = 11
+        versionName = "1.2.9"
         resourceConfigurations += listOf("zh-rCN", "en")
     }
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -85,6 +85,7 @@ dependencies {
     compileOnly(libs.legacy.xposed.api)
 
     implementation(libs.androidx.core.ktx)
+    implementation(libs.androidx.appcompat)
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.lifecycle.viewmodel.compose)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -146,6 +146,17 @@
                 android:resource="@xml/file_paths" />
         </provider>
 
+        <!-- 让 AppCompatDelegate.setApplicationLocales() 的语言选择与系统 LocaleManager 同步/持久化
+             （Android 13 以下必须声明此项，否则应用内切换语言不会真正生效或无法在重启后保留） -->
+        <service
+            android:name="androidx.appcompat.app.AppLocalesMetadataHolderService"
+            android:enabled="false"
+            android:exported="false">
+            <meta-data
+                android:name="autoStoreLocales"
+                android:value="true" />
+        </service>
+
     </application>
 
 </manifest>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -49,6 +49,7 @@
         android:label="@string/app_name"
         android:description="@string/xposed_description"
         android:roundIcon="@mipmap/ic_launcher_round"
+        android:localeConfig="@xml/locales_config"
         android:supportsRtl="true"
         android:theme="@style/Theme.GlassMic"
         tools:targetApi="35">

--- a/app/src/main/java/io/mo/glassmic/GlassApplication.kt
+++ b/app/src/main/java/io/mo/glassmic/GlassApplication.kt
@@ -71,6 +71,6 @@ class GlassApplication : Application() {
             }
             detected
         }
-        AppLocale.apply(resolved)
+        AppLocale.apply(this, resolved)
     }
 }

--- a/app/src/main/java/io/mo/glassmic/GlassApplication.kt
+++ b/app/src/main/java/io/mo/glassmic/GlassApplication.kt
@@ -4,11 +4,16 @@ import android.app.Application
 import dagger.hilt.android.HiltAndroidApp
 import io.mo.glassmic.core.Constants
 import io.mo.glassmic.core.model.SafeModeReason
+import io.mo.glassmic.data.config.AppLocale
+import io.mo.glassmic.data.config.ConfigStore
 import io.mo.glassmic.data.runtime.BootGateRepository
 import io.mo.glassmic.data.runtime.SafeModeRepository
 import io.mo.glassmic.log.GlassLog
+import io.mo.glassmic.proto.AppLanguage
 import io.mo.glassmic.service.SafeModeWatchdog
+import kotlinx.coroutines.runBlocking
 import java.io.File
+import java.util.Locale
 import javax.inject.Inject
 
 @HiltAndroidApp
@@ -17,9 +22,12 @@ class GlassApplication : Application() {
     @Inject lateinit var safeModeRepo: SafeModeRepository
     @Inject lateinit var bootGate: BootGateRepository
     @Inject lateinit var watchdog: SafeModeWatchdog
+    @Inject lateinit var configStore: ConfigStore
 
     override fun onCreate() {
         super.onCreate()
+
+        applyLanguagePreference()
 
         GlassLog.init(this)
 
@@ -46,5 +54,23 @@ class GlassApplication : Application() {
         }.start()
 
         GlassLog.b("App") { "GlassMic Application started" }
+    }
+
+    // 首次启动按系统语言自动决定默认语言（中文→中文，其余→英文），之后由用户在设置里显式选择。
+    private fun applyLanguagePreference() {
+        val appearance = runBlocking { configStore.current() }.appearance
+        val resolved = if (appearance.languageResolved) {
+            appearance.language
+        } else {
+            val systemIsChinese = Locale.getDefault().language == "zh"
+            val detected = if (systemIsChinese) AppLanguage.ZH else AppLanguage.EN
+            runBlocking {
+                configStore.update {
+                    it.setAppearance(it.appearance.toBuilder().setLanguage(detected).setLanguageResolved(true))
+                }
+            }
+            detected
+        }
+        AppLocale.apply(resolved)
     }
 }

--- a/app/src/main/java/io/mo/glassmic/MainActivity.kt
+++ b/app/src/main/java/io/mo/glassmic/MainActivity.kt
@@ -1,5 +1,6 @@
 package io.mo.glassmic
 
+import android.content.Context
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -16,6 +17,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import dagger.hilt.android.AndroidEntryPoint
 import dagger.hilt.android.lifecycle.HiltViewModel
+import io.mo.glassmic.data.config.AppLocale
 import io.mo.glassmic.data.config.ConfigStore
 import io.mo.glassmic.data.runtime.SafeModeRepository
 import io.mo.glassmic.ui.home.HomeScreen
@@ -34,6 +36,12 @@ import javax.inject.Inject
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
+
+    // MainActivity 不是 AppCompatActivity，Android 13 以下需要在这里手动按已保存的语言包一层
+    // Context，AppCompatDelegate.setApplicationLocales() 才能在冷启动时真正生效。
+    override fun attachBaseContext(newBase: Context) {
+        super.attachBaseContext(AppLocale.wrap(newBase))
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/io/mo/glassmic/data/config/AppLocale.kt
+++ b/app/src/main/java/io/mo/glassmic/data/config/AppLocale.kt
@@ -1,0 +1,17 @@
+package io.mo.glassmic.data.config
+
+import androidx.appcompat.app.AppCompatDelegate
+import androidx.core.os.LocaleListCompat
+import io.mo.glassmic.proto.AppLanguage
+
+/** 把用户选择的 [AppLanguage] 应用为进程当前的 Locale。 */
+object AppLocale {
+    fun apply(language: AppLanguage) {
+        val locales = when (language) {
+            AppLanguage.ZH -> LocaleListCompat.forLanguageTags("zh-CN")
+            AppLanguage.EN -> LocaleListCompat.forLanguageTags("en")
+            else -> LocaleListCompat.getEmptyLocaleList()
+        }
+        AppCompatDelegate.setApplicationLocales(locales)
+    }
+}

--- a/app/src/main/java/io/mo/glassmic/data/config/AppLocale.kt
+++ b/app/src/main/java/io/mo/glassmic/data/config/AppLocale.kt
@@ -1,17 +1,65 @@
 package io.mo.glassmic.data.config
 
+import android.content.Context
+import android.content.res.Configuration
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.os.LocaleListCompat
 import io.mo.glassmic.proto.AppLanguage
+import java.util.Locale
 
-/** 把用户选择的 [AppLanguage] 应用为进程当前的 Locale。 */
+/**
+ * 把用户选择的 [AppLanguage] 应用为进程当前的 Locale。
+ *
+ * [MainActivity] 是普通 ComponentActivity 而非 AppCompatActivity，Android 13 以下
+ * [AppCompatDelegate.setApplicationLocales] 不会自动改写它的 Resources（那套自动生效机制依赖
+ * AppCompatActivity#attachBaseContext 的包装）。因此这里额外把语言同步写入一份 SharedPreferences
+ * 缓存，供 [wrap] 在 attachBaseContext() 阶段同步读取并手动包一层 Locale Context，
+ * 保证 Android 10~12 也能正确生效并在重启后保留。
+ */
 object AppLocale {
-    fun apply(language: AppLanguage) {
-        val locales = when (language) {
-            AppLanguage.ZH -> LocaleListCompat.forLanguageTags("zh-CN")
-            AppLanguage.EN -> LocaleListCompat.forLanguageTags("en")
-            else -> LocaleListCompat.getEmptyLocaleList()
-        }
-        AppCompatDelegate.setApplicationLocales(locales)
+    private const val PREFS_NAME = "app_locale"
+    private const val KEY_LANGUAGE = "language"
+
+    fun apply(context: Context, language: AppLanguage) {
+        context.applicationContext
+            .getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .edit()
+            .putString(KEY_LANGUAGE, language.name)
+            .apply()
+        AppCompatDelegate.setApplicationLocales(toLocaleList(language))
+    }
+
+    /** 在 [android.app.Activity.attachBaseContext] 里调用，返回按已保存语言包装过的 Context。 */
+    fun wrap(base: Context): Context {
+        val locale = toLocale(restore(base)) ?: return base
+        val config = Configuration(base.resources.configuration).apply { setLocale(locale) }
+        return base.createConfigurationContext(config)
+    }
+
+    /**
+     * 供 ViewModel / Service 等非 Composable 场景使用的语言安全取字符串。
+     * 不能直接用注入的 [android.content.Context] 调 getString()——Android 13 以下它不会
+     * 跟随应用内切换的语言，这里统一走 [wrap] 保证跟 UI 显示的语言一致。
+     */
+    fun string(context: Context, resId: Int, vararg formatArgs: Any): String =
+        if (formatArgs.isEmpty()) wrap(context).getString(resId)
+        else wrap(context).getString(resId, *formatArgs)
+
+    private fun restore(context: Context): AppLanguage {
+        val name = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .getString(KEY_LANGUAGE, null) ?: return AppLanguage.SYSTEM
+        return runCatching { AppLanguage.valueOf(name) }.getOrDefault(AppLanguage.SYSTEM)
+    }
+
+    private fun toLocaleList(language: AppLanguage): LocaleListCompat = when (language) {
+        AppLanguage.ZH -> LocaleListCompat.forLanguageTags("zh-CN")
+        AppLanguage.EN -> LocaleListCompat.forLanguageTags("en")
+        else -> LocaleListCompat.getEmptyLocaleList()
+    }
+
+    private fun toLocale(language: AppLanguage): Locale? = when (language) {
+        AppLanguage.ZH -> Locale.SIMPLIFIED_CHINESE
+        AppLanguage.EN -> Locale.ENGLISH
+        else -> null
     }
 }

--- a/app/src/main/java/io/mo/glassmic/service/FloatingBubbleUi.kt
+++ b/app/src/main/java/io/mo/glassmic/service/FloatingBubbleUi.kt
@@ -47,11 +47,13 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import io.mo.glassmic.R
 import kotlinx.coroutines.flow.Flow
 import java.io.File
 
@@ -270,7 +272,7 @@ private fun MiniBar(
                 modifier = Modifier.weight(1f)
             )
             // 换音源
-            IconChip(Icons.Filled.Refresh, "换音源", onOpenMenu)
+            IconChip(Icons.Filled.Refresh, stringResource(R.string.float_change_source), onOpenMenu)
             Spacer(Modifier.width(6.dp))
             // 播放/暂停
             Text(
@@ -292,7 +294,7 @@ private fun MiniBar(
         Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
             Text(formatMs(positionMs), color = OnDarkDim, fontSize = 11.sp)
             Text(
-                "收起",
+                stringResource(R.string.float_collapse),
                 color = OnDarkDim,
                 fontSize = 11.sp,
                 modifier = Modifier.clickable(onClick = onCollapse)
@@ -348,20 +350,20 @@ private fun SelectMenu(
         ) {
             if (selectedGroup != null) {
                 Icon(
-                    Icons.AutoMirrored.Filled.ArrowBack, "返回", tint = OnDark,
+                    Icons.AutoMirrored.Filled.ArrowBack, stringResource(R.string.float_back), tint = OnDark,
                     modifier = Modifier.size(22.dp).clip(CircleShape)
                         .clickable { selectedGroup = null }.padding(2.dp)
                 )
                 Spacer(Modifier.width(8.dp))
             }
             Text(
-                text = selectedGroup?.let { "${it.emoji} ${it.name}" } ?: "选择音频",
+                text = selectedGroup?.let { "${it.emoji} ${it.name}" } ?: stringResource(R.string.home_pick_audio),
                 color = OnDark, fontSize = 14.sp, fontWeight = FontWeight.SemiBold,
                 maxLines = 1, overflow = TextOverflow.Ellipsis,
                 modifier = Modifier.weight(1f)
             )
             Text(
-                "收起", color = OnDarkDim, fontSize = 12.sp,
+                stringResource(R.string.float_collapse), color = OnDarkDim, fontSize = 12.sp,
                 modifier = Modifier.clickable(onClick = onCollapse)
             )
         }
@@ -369,9 +371,9 @@ private fun SelectMenu(
         val group = selectedGroup
         if (group == null) {
             // 文字转语音入口：输入文字实时合成喂给目标 App
-            MenuRow(text = "🗣  文字转语音（TTS）", trailing = "›", onClick = onOpenTts)
+            MenuRow(text = stringResource(R.string.float_tts_entry), trailing = "›", onClick = onOpenTts)
             if (groups.isEmpty()) {
-                EmptyHint("还没有音频分组")
+                EmptyHint(stringResource(R.string.float_no_groups))
             } else {
                 LazyColumn {
                     items(groups, key = { it.id }) { g ->
@@ -385,7 +387,7 @@ private fun SelectMenu(
             val clipsFlow = remember(group.id) { clipsProvider(group.id) }
             val clips by clipsFlow.collectAsState(initial = emptyList())
             if (clips.isEmpty()) {
-                EmptyHint("该分组还没有音频")
+                EmptyHint(stringResource(R.string.float_no_clips_in_group))
             } else {
                 LazyColumn {
                     items(clips, key = { it.id }) { c ->
@@ -432,12 +434,12 @@ private fun TtsPanel(
             verticalAlignment = Alignment.CenterVertically
         ) {
             Text(
-                "🗣 文字转语音", color = OnDark, fontSize = 14.sp,
+                stringResource(R.string.float_tts_title), color = OnDark, fontSize = 14.sp,
                 fontWeight = FontWeight.SemiBold, modifier = Modifier.weight(1f)
             )
             Icon(
                 imageVector = Icons.Filled.Settings,
-                contentDescription = "设置",
+                contentDescription = stringResource(R.string.float_settings),
                 tint = OnDarkDim,
                 modifier = Modifier
                     .size(26.dp)
@@ -447,7 +449,7 @@ private fun TtsPanel(
             )
             Spacer(Modifier.width(10.dp))
             Text(
-                "收起", color = OnDarkDim, fontSize = 12.sp,
+                stringResource(R.string.float_collapse), color = OnDarkDim, fontSize = 12.sp,
                 modifier = Modifier.clickable(onClick = onCollapse)
             )
         }
@@ -467,7 +469,7 @@ private fun TtsPanel(
                 modifier = Modifier.fillMaxWidth().heightIn(min = 56.dp),
                 decorationBox = { inner ->
                     if (text.isEmpty()) {
-                        Text("输入要合成的文字，先生成再播放", color = OnDarkDim, fontSize = 14.sp)
+                        Text(stringResource(R.string.float_tts_input_hint), color = OnDarkDim, fontSize = 14.sp)
                     }
                     inner()
                 }
@@ -480,7 +482,7 @@ private fun TtsPanel(
         ) {
             val canGenerate = !generating && text.isNotBlank()
             Text(
-                text = if (generating) "生成中…" else "生成",
+                text = if (generating) stringResource(R.string.float_tts_generating) else stringResource(R.string.float_tts_generate),
                 color = OnDark,
                 fontSize = 14.sp,
                 fontWeight = FontWeight.Medium,
@@ -492,7 +494,7 @@ private fun TtsPanel(
             )
             Spacer(Modifier.width(10.dp))
             Text(
-                text = "播放",
+                text = stringResource(R.string.float_tts_play),
                 color = OnDark,
                 fontSize = 14.sp,
                 fontWeight = FontWeight.Medium,
@@ -506,7 +508,7 @@ private fun TtsPanel(
         // 仅在失败时提示，正常流程不堆文字
         if (failed) {
             Text(
-                text = "生成失败，请检查网络或 TTS 引擎后重试",
+                text = stringResource(R.string.float_tts_generate_failed),
                 color = Danger, fontSize = 11.sp,
                 modifier = Modifier.padding(top = 8.dp)
             )
@@ -551,13 +553,13 @@ private fun TtsSettingsPanel(
             verticalAlignment = Alignment.CenterVertically
         ) {
             Icon(
-                Icons.AutoMirrored.Filled.ArrowBack, "返回", tint = OnDark,
+                Icons.AutoMirrored.Filled.ArrowBack, stringResource(R.string.float_back), tint = OnDark,
                 modifier = Modifier.size(22.dp).clip(CircleShape)
                     .clickable(onClick = onBack).padding(2.dp)
             )
             Spacer(Modifier.width(8.dp))
             Text(
-                "文字转语音设置", color = OnDark, fontSize = 14.sp,
+                stringResource(R.string.float_tts_settings_title), color = OnDark, fontSize = 14.sp,
                 fontWeight = FontWeight.SemiBold, modifier = Modifier.weight(1f)
             )
         }
@@ -567,7 +569,7 @@ private fun TtsSettingsPanel(
             verticalAlignment = Alignment.CenterVertically
         ) {
             Text(
-                "播放进度条", color = OnDark, fontSize = 14.sp,
+                stringResource(R.string.float_tts_progress_bar), color = OnDark, fontSize = 14.sp,
                 modifier = Modifier.weight(1f)
             )
             Switch(
@@ -593,7 +595,7 @@ private fun MenuRow(
         verticalAlignment = Alignment.CenterVertically
     ) {
         if (leadingCurrent) {
-            Icon(Icons.Filled.Check, "当前", tint = Accent, modifier = Modifier.size(16.dp))
+            Icon(Icons.Filled.Check, stringResource(R.string.float_current), tint = Accent, modifier = Modifier.size(16.dp))
             Spacer(Modifier.width(8.dp))
         }
         Text(

--- a/app/src/main/java/io/mo/glassmic/service/FloatingWindowService.kt
+++ b/app/src/main/java/io/mo/glassmic/service/FloatingWindowService.kt
@@ -19,6 +19,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import io.mo.glassmic.core.model.SourceType
 import io.mo.glassmic.data.audio.FloatingIconStore
 import io.mo.glassmic.data.audio.PlaybackController
+import io.mo.glassmic.data.config.AppLocale
 import io.mo.glassmic.data.config.ConfigStore
 import io.mo.glassmic.data.db.AudioDao
 import io.mo.glassmic.data.runtime.RuntimeStateHolder
@@ -109,7 +110,9 @@ class FloatingWindowService : LifecycleService() {
         }
         params = lp
 
-        val overlayHost = FloatingOverlayHost(this).also { it.onCreate() }
+        // Service 不是 Activity，Android 13 以下不会自动跟随应用内切换的语言，
+        // 这里手动包一层 Locale Context 传给 ComposeView，保证悬浮窗文案也能正确显示。
+        val overlayHost = FloatingOverlayHost(AppLocale.wrap(this)).also { it.onCreate() }
         host = overlayHost
         overlayHost.setContent {
             MaterialTheme {

--- a/app/src/main/java/io/mo/glassmic/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/io/mo/glassmic/ui/home/HomeViewModel.kt
@@ -5,8 +5,10 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
+import io.mo.glassmic.R
 import io.mo.glassmic.core.model.SourceType
 import io.mo.glassmic.data.audio.PlaybackController
+import io.mo.glassmic.data.config.AppLocale
 import io.mo.glassmic.data.config.ConfigStore
 import io.mo.glassmic.data.db.AudioDao
 import io.mo.glassmic.data.runtime.BootGateRepository
@@ -82,22 +84,22 @@ class HomeViewModel @Inject constructor(
             paused = rt.paused,
             sourceName = when (rt.currentSourceType) {
                 SourceType.FILE -> clip?.displayName ?: rt.currentAudioId ?: "—"
-                SourceType.REAL_MIC -> "真实麦克风"
-                SourceType.SILENCE -> "静音"
-                SourceType.TTS -> "文字转语音"
+                SourceType.REAL_MIC -> AppLocale.string(context, R.string.source_real_mic)
+                SourceType.SILENCE -> AppLocale.string(context, R.string.source_silence)
+                SourceType.TTS -> AppLocale.string(context, R.string.source_tts)
             },
             groupName = group?.let { "${it.emoji} ${it.name}" } ?: "—",
             policyLabel = when (cfg.playbackPolicy) {
-                ProtoPolicy.SILENCE -> "静音"
-                ProtoPolicy.LOOP -> "循环"
-                ProtoPolicy.REAL_MIC -> "切回真实麦克风"
-                else -> "循环"
+                ProtoPolicy.SILENCE -> AppLocale.string(context, R.string.home_policy_silence)
+                ProtoPolicy.LOOP -> AppLocale.string(context, R.string.library_policy_loop)
+                ProtoPolicy.REAL_MIC -> AppLocale.string(context, R.string.library_policy_real_mic)
+                else -> AppLocale.string(context, R.string.library_policy_loop)
             },
             scopeLabel = when (cfg.scopeMode) {
-                ProtoScope.GLOBAL -> "全系统"
-                ProtoScope.WHITELIST -> "白名单（${cfg.whitelistCount}）"
+                ProtoScope.GLOBAL -> AppLocale.string(context, R.string.scope_mode_global)
+                ProtoScope.WHITELIST -> AppLocale.string(context, R.string.home_scope_whitelist_count, cfg.whitelistCount)
                 // BLACKLIST 已在 UI 上隐藏；旧配置统一按"全系统"展示
-                else -> "全系统"
+                else -> AppLocale.string(context, R.string.scope_mode_global)
             },
             floatingWindowVisible = rt.floatingWindowVisible,
             positionMs = rt.positionMs,

--- a/app/src/main/java/io/mo/glassmic/ui/settings/AiTtsSettingsScreen.kt
+++ b/app/src/main/java/io/mo/glassmic/ui/settings/AiTtsSettingsScreen.kt
@@ -40,8 +40,10 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import io.mo.glassmic.R
 import io.mo.glassmic.proto.TtsProvider
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -72,10 +74,10 @@ fun AiTtsSettingsScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("AI 供应商（TTS）") },
+                title = { Text(stringResource(R.string.ai_tts_title)) },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "返回")
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(R.string.common_back))
                     }
                 }
             )
@@ -90,34 +92,33 @@ fun AiTtsSettingsScreen(
             verticalArrangement = Arrangement.spacedBy(8.dp)
         ) {
             item {
-                Section("接入") {
-                    SwitchRow(label = "启用 AI TTS", checked = ai.enabled, onChange = vm::setEnabled)
+                Section(stringResource(R.string.ai_tts_section_access)) {
+                    SwitchRow(label = stringResource(R.string.ai_tts_enable), checked = ai.enabled, onChange = vm::setEnabled)
                     ProviderPicker(ai.provider, vm::setProvider)
                 }
             }
 
             item {
-                Section("接口") {
-                    ConfigTextField("自定义地址 endpoint（留空用官方默认）", ai.endpoint, vm::setEndpoint)
-                    ConfigTextField("API Key", ai.apiKey, vm::setApiKey)
-                    ConfigTextField("自定义模型 model（留空用默认）", ai.model, vm::setModel)
+                Section(stringResource(R.string.ai_tts_section_endpoint)) {
+                    ConfigTextField(stringResource(R.string.ai_tts_endpoint_hint), ai.endpoint, vm::setEndpoint)
+                    ConfigTextField(stringResource(R.string.ai_tts_api_key), ai.apiKey, vm::setApiKey)
+                    ConfigTextField(stringResource(R.string.ai_tts_model_hint), ai.model, vm::setModel)
                     ModelPickerRow(vm.models.collectAsState().value, onFetch = vm::fetchModels, onPick = vm::setModel)
                 }
             }
 
             item {
-                Section("音色") {
-                    ConfigTextField("音色 voice（preset / OpenAI / Gemini）", ai.voice, vm::setVoice)
+                Section(stringResource(R.string.ai_tts_section_voice)) {
+                    ConfigTextField(stringResource(R.string.ai_tts_voice_hint), ai.voice, vm::setVoice)
                     if (ai.provider == TtsProvider.MIMO) {
                         Text(
-                            "MiMo 进阶：模型填 -voicedesign 用文本描述定制音色（写在下方描述框）；" +
-                                "填 -voiceclone 复刻音色（选一段 ≤60 秒、≤5MB 的参考音频）。",
+                            stringResource(R.string.ai_tts_mimo_advanced),
                             style = MaterialTheme.typography.bodySmall,
                             color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f),
                             modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp)
                         )
                         ConfigTextField(
-                            "音色描述 / 风格（voicedesign 必填，preset 可选）",
+                            stringResource(R.string.ai_tts_style_prompt_hint),
                             ai.stylePrompt, vm::setStylePrompt
                         )
                         CloneSampleRow(
@@ -126,18 +127,19 @@ fun AiTtsSettingsScreen(
                             onClear = { vm.setCloneSample(null) }
                         )
                     }
-                    ConfigTextField("返回格式 format（OpenAI：wav / pcm）", ai.format, vm::setFormat)
+                    ConfigTextField(stringResource(R.string.ai_tts_format_hint), ai.format, vm::setFormat)
                 }
             }
 
             item {
-                Section("测试与试听") {
+                Section(stringResource(R.string.ai_tts_section_test)) {
                     TestRow(vm.test.collectAsState().value, onTest = vm::testConnection)
-                    var previewText by remember { mutableStateOf("你好，这是一段用于试听的示例文本。") }
+                    val defaultPreviewText = stringResource(R.string.ai_tts_preview_default_text)
+                    var previewText by remember { mutableStateOf(defaultPreviewText) }
                     OutlinedTextField(
                         value = previewText,
                         onValueChange = { previewText = it },
-                        label = { Text("试听文本") },
+                        label = { Text(stringResource(R.string.ai_tts_preview_text_label)) },
                         minLines = 2,
                         maxLines = 4,
                         modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 6.dp)
@@ -161,13 +163,13 @@ private fun ProviderPicker(current: TtsProvider, onSelect: (TtsProvider) -> Unit
     val effective = if (current == TtsProvider.UNRECOGNIZED) TtsProvider.OPENAI else current
     Column {
         Text(
-            "接口协议",
+            stringResource(R.string.ai_tts_protocol),
             style = MaterialTheme.typography.bodyLarge,
             modifier = Modifier.padding(start = 16.dp, top = 12.dp, end = 16.dp)
         )
-        PolicyOption("OpenAI（/audio/speech）", effective == TtsProvider.OPENAI) { onSelect(TtsProvider.OPENAI) }
-        PolicyOption("Google Gemini（generateContent）", effective == TtsProvider.GEMINI) { onSelect(TtsProvider.GEMINI) }
-        PolicyOption("小米 MiMo（chat/completions）", effective == TtsProvider.MIMO) { onSelect(TtsProvider.MIMO) }
+        PolicyOption(stringResource(R.string.ai_tts_provider_openai), effective == TtsProvider.OPENAI) { onSelect(TtsProvider.OPENAI) }
+        PolicyOption(stringResource(R.string.ai_tts_provider_gemini), effective == TtsProvider.GEMINI) { onSelect(TtsProvider.GEMINI) }
+        PolicyOption(stringResource(R.string.ai_tts_provider_mimo), effective == TtsProvider.MIMO) { onSelect(TtsProvider.MIMO) }
     }
 }
 
@@ -182,7 +184,7 @@ private fun ModelPickerRow(state: TtsModelsState, onFetch: () -> Unit, onPick: (
     ) {
         Box {
             TextButton(onClick = onFetch, enabled = !loading) {
-                Text(if (loading) "获取中…" else "获取模型")
+                Text(if (loading) stringResource(R.string.ai_tts_fetching_models) else stringResource(R.string.ai_tts_fetch_models))
             }
             DropdownMenu(expanded = open, onDismissRequest = { open = false }) {
                 (state as? TtsModelsState.Loaded)?.models?.forEach { m ->
@@ -199,7 +201,7 @@ private fun ModelPickerRow(state: TtsModelsState, onFetch: () -> Unit, onPick: (
                 modifier = Modifier.weight(1f)
             )
             is TtsModelsState.Loaded -> Text(
-                "共 ${state.models.size} 个，点此重选",
+                stringResource(R.string.ai_tts_models_count, state.models.size),
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f),
                 modifier = Modifier.weight(1f).clickable { open = true }
@@ -216,15 +218,15 @@ private fun CloneSampleRow(hasSample: Boolean, onPick: () -> Unit, onClear: () -
         verticalAlignment = Alignment.CenterVertically
     ) {
         Column(modifier = Modifier.weight(1f)) {
-            Text("参考音频（voiceclone）", style = MaterialTheme.typography.bodyLarge)
+            Text(stringResource(R.string.ai_tts_clone_sample), style = MaterialTheme.typography.bodyLarge)
             Text(
-                if (hasSample) "已选择样本（≤60 秒 / ≤5MB）" else "未选择——复刻音色需先选一段音频样本",
+                if (hasSample) stringResource(R.string.ai_tts_clone_sample_selected) else stringResource(R.string.ai_tts_clone_sample_none),
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f)
             )
         }
-        if (hasSample) TextButton(onClick = onClear) { Text("清除") }
-        TextButton(onClick = onPick) { Text("选择音频") }
+        if (hasSample) TextButton(onClick = onClear) { Text(stringResource(R.string.ai_tts_clear)) }
+        TextButton(onClick = onPick) { Text(stringResource(R.string.ai_tts_choose_audio)) }
     }
 }
 
@@ -243,16 +245,16 @@ private fun PreviewRow(
         verticalAlignment = Alignment.CenterVertically
     ) {
         TextButton(onClick = onGenerate, enabled = !generating) {
-            Text(if (generating) "生成中…" else "生成")
+            Text(if (generating) stringResource(R.string.ai_tts_generating) else stringResource(R.string.ai_tts_generate))
         }
         Spacer(modifier = Modifier.width(4.dp))
         TextButton(onClick = onPlay, enabled = ready && !playing) {
-            Text(if (playing) "播放中…" else "效果试听")
+            Text(if (playing) stringResource(R.string.ai_tts_preview_playing) else stringResource(R.string.ai_tts_preview_play))
         }
         // 生成出试听音频后才显示「保存音频」
         if (ready) {
             Spacer(modifier = Modifier.width(4.dp))
-            TextButton(onClick = onSave) { Text("保存音频") }
+            TextButton(onClick = onSave) { Text(stringResource(R.string.ai_tts_save_audio)) }
         }
         Spacer(modifier = Modifier.width(8.dp))
         if (state is TtsPreviewState.Error) {
@@ -274,7 +276,7 @@ private fun TestRow(state: TtsTestState, onTest: () -> Unit) {
         verticalAlignment = Alignment.CenterVertically
     ) {
         TextButton(onClick = onTest, enabled = !testing) {
-            Text(if (testing) "测试中…" else "测试连接")
+            Text(if (testing) stringResource(R.string.ai_tts_testing) else stringResource(R.string.ai_tts_test_connection))
         }
         Spacer(modifier = Modifier.width(8.dp))
         if (state is TtsTestState.Result) {

--- a/app/src/main/java/io/mo/glassmic/ui/settings/AiTtsViewModel.kt
+++ b/app/src/main/java/io/mo/glassmic/ui/settings/AiTtsViewModel.kt
@@ -10,11 +10,13 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
+import io.mo.glassmic.R
 import io.mo.glassmic.audio.tts.AiTtsSynthesizer
 import io.mo.glassmic.audio.tts.PcmSink
 import io.mo.glassmic.audio.tts.TtsRequest
 import io.mo.glassmic.data.audio.SampleImport
 import io.mo.glassmic.data.audio.TtsCloneSampleStore
+import io.mo.glassmic.data.config.AppLocale
 import io.mo.glassmic.data.config.ConfigStore
 import io.mo.glassmic.proto.AppConfig
 import io.mo.glassmic.proto.TtsAiConfig
@@ -119,16 +121,18 @@ class AiTtsViewModel @Inject constructor(
                     override fun onFormat(sampleRate: Int, channels: Int) {}
                     override fun onPcm(chunk: ByteArray) { bytes += chunk.size }
                     override fun onDone() {
-                        if (cont.isActive) cont.resumeWith(Result.success(true to "连接成功，收到 ${bytes / 1024} KB 音频"))
+                        if (cont.isActive) {
+                            cont.resumeWith(Result.success(true to AppLocale.string(context, R.string.ai_tts_connected_ok, bytes / 1024)))
+                        }
                     }
                     override fun onError(message: String) {
                         if (cont.isActive) cont.resumeWith(Result.success(false to message))
                     }
                 }
-                aiTts.synthesize(TtsRequest("这是一段连接测试。"), sink)
+                aiTts.synthesize(TtsRequest(AppLocale.string(context, R.string.ai_tts_test_phrase)), sink)
                 cont.invokeOnCancellation { aiTts.cancel() }
             }
-        } ?: (false to "测试超时（25 秒）")
+        } ?: (false to AppLocale.string(context, R.string.ai_tts_test_timeout))
         _test.value = TtsTestState.Result(result.first, result.second)
     }
 
@@ -140,8 +144,11 @@ class AiTtsViewModel @Inject constructor(
         if (_models.value is TtsModelsState.Loading) return@launch
         _models.value = TtsModelsState.Loading
         _models.value = runCatching { aiTts.fetchModels() }.fold(
-            onSuccess = { if (it.isEmpty()) TtsModelsState.Error("接口未返回模型") else TtsModelsState.Loaded(it) },
-            onFailure = { TtsModelsState.Error(it.message ?: "获取失败") }
+            onSuccess = {
+                if (it.isEmpty()) TtsModelsState.Error(AppLocale.string(context, R.string.ai_tts_no_models_returned))
+                else TtsModelsState.Loaded(it)
+            },
+            onFailure = { TtsModelsState.Error(it.message ?: AppLocale.string(context, R.string.ai_tts_fetch_models_failed)) }
         )
     }
 
@@ -159,7 +166,7 @@ class AiTtsViewModel @Inject constructor(
     fun generatePreview(text: String) {
         val t = text.trim()
         if (t.isEmpty()) {
-            _preview.value = TtsPreviewState.Error("请先输入试听文本")
+            _preview.value = TtsPreviewState.Error(AppLocale.string(context, R.string.ai_tts_enter_preview_text))
             return
         }
         stopPlayback()
@@ -177,7 +184,7 @@ class AiTtsViewModel @Inject constructor(
             override fun onDone() {
                 val pcm = out.toByteArray()
                 if (pcm.isEmpty()) {
-                    _preview.value = TtsPreviewState.Error("未获取到音频")
+                    _preview.value = TtsPreviewState.Error(AppLocale.string(context, R.string.ai_tts_no_audio_received))
                 } else {
                     generatedPcm = pcm; generatedSr = sr; generatedCh = ch
                     _preview.value = TtsPreviewState.Ready(pcm.size)
@@ -191,7 +198,7 @@ class AiTtsViewModel @Inject constructor(
     /** 播放上次生成的语音（可重复调用重播）。 */
     fun playPreview() {
         val pcm = generatedPcm ?: run {
-            _preview.value = TtsPreviewState.Error("请先点「生成」")
+            _preview.value = TtsPreviewState.Error(AppLocale.string(context, R.string.ai_tts_generate_first))
             return
         }
         startPlayback(pcm, generatedSr, generatedCh)
@@ -262,7 +269,7 @@ class AiTtsViewModel @Inject constructor(
     fun saveGeneratedTo(uri: Uri) {
         val pcm = generatedPcm
         if (pcm == null) {
-            _saveMessage.value = "请先生成音频"
+            _saveMessage.value = AppLocale.string(context, R.string.ai_tts_generate_audio_first)
             return
         }
         val sr = generatedSr
@@ -272,7 +279,7 @@ class AiTtsViewModel @Inject constructor(
                 context.contentResolver.openOutputStream(uri)?.use { out -> writeWav(out, pcm, sr, ch) }
                     ?: error("无法打开输出流")
             }.isSuccess
-            _saveMessage.value = if (ok) "已保存音频" else "保存失败"
+            _saveMessage.value = AppLocale.string(context, if (ok) R.string.ai_tts_saved else R.string.ai_tts_save_failed)
         }
     }
 

--- a/app/src/main/java/io/mo/glassmic/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/io/mo/glassmic/ui/settings/SettingsScreen.kt
@@ -1,5 +1,6 @@
 package io.mo.glassmic.ui.settings
 
+import android.app.Activity
 import android.app.StatusBarManager
 import android.content.ComponentName
 import android.content.Intent
@@ -133,7 +134,7 @@ fun SettingsScreen(
                 title = { Text(stringResource(R.string.settings_title)) },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "返回")
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(R.string.common_back))
                     }
                 }
             )
@@ -159,7 +160,12 @@ fun SettingsScreen(
 
             item { Section(stringResource(R.string.settings_section_appearance)) {
                 ThemePicker(cfg.appearance.theme, vm::setTheme)
-                LanguagePicker(cfg.appearance.language, vm::setLanguage)
+                LanguagePicker(cfg.appearance.language) { lang ->
+                    vm.setLanguage(lang)
+                    // MainActivity 非 AppCompatActivity，Android 13 以下切换语言后需要手动
+                    // recreate() 才能让新的 attachBaseContext() 包装立即生效，而不必等下次冷启动。
+                    (context as? Activity)?.recreate()
+                }
             } }
 
             item { Section(stringResource(R.string.settings_section_floating)) {
@@ -283,10 +289,14 @@ fun SettingsScreen(
                 }
             } }
 
-            item { Section("语音合成") {
+            item { Section(stringResource(R.string.settings_section_ai_tts)) {
                 NavRow(
-                    title = "AI 供应商（TTS）",
-                    subtitle = if (cfg.tts.ai.enabled) "已启用 · ${providerLabel(cfg.tts.ai.provider)}" else "使用系统 TTS（点击配置在线 AI）",
+                    title = stringResource(R.string.ai_tts_title),
+                    subtitle = if (cfg.tts.ai.enabled) {
+                        stringResource(R.string.ai_tts_nav_enabled, providerLabel(cfg.tts.ai.provider))
+                    } else {
+                        stringResource(R.string.ai_tts_nav_disabled)
+                    },
                     onClick = onOpenAiTts
                 )
             } }

--- a/app/src/main/java/io/mo/glassmic/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/io/mo/glassmic/ui/settings/SettingsScreen.kt
@@ -25,6 +25,11 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.KeyboardArrowUp
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -43,14 +48,17 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import io.mo.glassmic.BuildConfig
@@ -190,18 +198,7 @@ fun SettingsScreen(
             } }
 
             item { Section(stringResource(R.string.settings_section_policy)) {
-                Text(
-                    stringResource(R.string.settings_policy_hint),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f),
-                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp)
-                )
-                PolicyOption(stringResource(R.string.library_policy_loop),
-                    cfg.playbackPolicy == PlaybackPolicy.LOOP) { vm.setPolicy(PlaybackPolicy.LOOP) }
-                PolicyOption(stringResource(R.string.library_policy_silence),
-                    cfg.playbackPolicy == PlaybackPolicy.SILENCE) { vm.setPolicy(PlaybackPolicy.SILENCE) }
-                PolicyOption(stringResource(R.string.library_policy_real_mic),
-                    cfg.playbackPolicy == PlaybackPolicy.REAL_MIC) { vm.setPolicy(PlaybackPolicy.REAL_MIC) }
+                PlaybackPolicyPicker(cfg.playbackPolicy, vm::setPolicy)
             } }
 
             item { Section(stringResource(R.string.settings_section_diag)) {
@@ -438,60 +435,131 @@ internal fun PolicyOption(label: String, selected: Boolean, onSelect: () -> Unit
     }
 }
 
+// ============ 可折叠下拉选择行（点击展开为悬浮菜单） ============
+@Composable
+internal fun <T> DropdownPickerRow(
+    title: String,
+    hint: String? = null,
+    current: T,
+    options: List<Pair<String, T>>,
+    onSelect: (T) -> Unit
+) {
+    var expanded by remember { mutableStateOf(false) }
+    val currentLabel = options.firstOrNull { it.second == current }?.first.orEmpty()
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { expanded = true }
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(title, style = MaterialTheme.typography.bodyLarge)
+            if (!hint.isNullOrBlank()) {
+                Text(
+                    hint, style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f)
+                )
+            }
+        }
+        Box {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    currentLabel,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f)
+                )
+                Icon(
+                    imageVector = if (expanded) Icons.Filled.KeyboardArrowUp else Icons.Filled.KeyboardArrowDown,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f),
+                    modifier = Modifier.padding(start = 4.dp)
+                )
+            }
+            DropdownMenu(
+                expanded = expanded,
+                onDismissRequest = { expanded = false },
+                offset = DpOffset(x = 0.dp, y = 4.dp),
+                shape = RoundedCornerShape(16.dp)
+            ) {
+                options.forEach { (label, value) ->
+                    DropdownMenuItem(
+                        text = { Text(label) },
+                        onClick = { onSelect(value); expanded = false },
+                        trailingIcon = {
+                            if (value == current) {
+                                Icon(
+                                    Icons.Filled.Check, contentDescription = null,
+                                    tint = MaterialTheme.colorScheme.primary
+                                )
+                            }
+                        }
+                    )
+                }
+            }
+        }
+    }
+}
+
 // ============ 主题 ============
 @Composable
 private fun ThemePicker(current: ThemeMode, onSelect: (ThemeMode) -> Unit) {
-    Column {
-        Text(
-            stringResource(R.string.settings_theme),
-            style = MaterialTheme.typography.bodyLarge,
-            modifier = Modifier.padding(start = 16.dp, top = 12.dp, end = 16.dp)
-        )
-        PolicyOption(stringResource(R.string.settings_theme_follow),
-            current == ThemeMode.FOLLOW_SYSTEM) { onSelect(ThemeMode.FOLLOW_SYSTEM) }
-        PolicyOption(stringResource(R.string.settings_theme_light),
-            current == ThemeMode.LIGHT) { onSelect(ThemeMode.LIGHT) }
-        PolicyOption(stringResource(R.string.settings_theme_dark),
-            current == ThemeMode.DARK) { onSelect(ThemeMode.DARK) }
-    }
+    DropdownPickerRow(
+        title = stringResource(R.string.settings_theme),
+        current = current,
+        options = listOf(
+            stringResource(R.string.settings_theme_follow) to ThemeMode.FOLLOW_SYSTEM,
+            stringResource(R.string.settings_theme_light) to ThemeMode.LIGHT,
+            stringResource(R.string.settings_theme_dark) to ThemeMode.DARK
+        ),
+        onSelect = onSelect
+    )
 }
 
 // ============ 语言 ============
 @Composable
 private fun LanguagePicker(current: AppLanguage, onSelect: (AppLanguage) -> Unit) {
-    Column {
-        Text(
-            stringResource(R.string.settings_language),
-            style = MaterialTheme.typography.bodyLarge,
-            modifier = Modifier.padding(start = 16.dp, top = 12.dp, end = 16.dp)
-        )
-        PolicyOption(stringResource(R.string.settings_language_follow),
-            current == AppLanguage.SYSTEM) { onSelect(AppLanguage.SYSTEM) }
-        PolicyOption(stringResource(R.string.settings_language_zh),
-            current == AppLanguage.ZH) { onSelect(AppLanguage.ZH) }
-        PolicyOption(stringResource(R.string.settings_language_en),
-            current == AppLanguage.EN) { onSelect(AppLanguage.EN) }
-    }
+    DropdownPickerRow(
+        title = stringResource(R.string.settings_language),
+        current = current,
+        options = listOf(
+            stringResource(R.string.settings_language_follow) to AppLanguage.SYSTEM,
+            stringResource(R.string.settings_language_zh) to AppLanguage.ZH,
+            stringResource(R.string.settings_language_en) to AppLanguage.EN
+        ),
+        onSelect = onSelect
+    )
+}
+
+// ============ 默认播放策略 ============
+@Composable
+private fun PlaybackPolicyPicker(current: PlaybackPolicy, onSelect: (PlaybackPolicy) -> Unit) {
+    DropdownPickerRow(
+        title = stringResource(R.string.settings_policy_hint),
+        current = current,
+        options = listOf(
+            stringResource(R.string.library_policy_loop) to PlaybackPolicy.LOOP,
+            stringResource(R.string.library_policy_silence) to PlaybackPolicy.SILENCE,
+            stringResource(R.string.library_policy_real_mic) to PlaybackPolicy.REAL_MIC
+        ),
+        onSelect = onSelect
+    )
 }
 
 // ============ 日志级别 ============
 @Composable
 private fun LogLevelPicker(current: LogLevel, onSelect: (LogLevel) -> Unit) {
-    Column {
-        Text(
-            stringResource(R.string.settings_log_level),
-            style = MaterialTheme.typography.bodyLarge,
-            modifier = Modifier.padding(start = 16.dp, top = 12.dp, end = 16.dp)
-        )
-        PolicyOption(stringResource(R.string.settings_log_off),
-            current == LogLevel.OFF) { onSelect(LogLevel.OFF) }
-        PolicyOption(stringResource(R.string.settings_log_basic),
-            current == LogLevel.BASIC) { onSelect(LogLevel.BASIC) }
-        PolicyOption(stringResource(R.string.settings_log_verbose),
-            current == LogLevel.VERBOSE) { onSelect(LogLevel.VERBOSE) }
-        PolicyOption(stringResource(R.string.settings_log_debug),
-            current == LogLevel.DEBUG) { onSelect(LogLevel.DEBUG) }
-    }
+    DropdownPickerRow(
+        title = stringResource(R.string.settings_log_level),
+        current = current,
+        options = listOf(
+            stringResource(R.string.settings_log_off) to LogLevel.OFF,
+            stringResource(R.string.settings_log_basic) to LogLevel.BASIC,
+            stringResource(R.string.settings_log_verbose) to LogLevel.VERBOSE,
+            stringResource(R.string.settings_log_debug) to LogLevel.DEBUG
+        ),
+        onSelect = onSelect
+    )
 }
 
 // ============ 悬浮窗不透明度 ============
@@ -535,20 +603,17 @@ private fun LabeledSlider(
 // ============ 悬浮球大小 ============
 @Composable
 private fun FloatingSizePicker(current: FloatingSize, onSelect: (FloatingSize) -> Unit) {
-    Column {
-        Text(
-            stringResource(R.string.settings_floating_size),
-            style = MaterialTheme.typography.bodyLarge,
-            modifier = Modifier.padding(start = 16.dp, top = 12.dp, end = 16.dp)
-        )
-        val effective = if (current == FloatingSize.UNRECOGNIZED) FloatingSize.STANDARD else current
-        PolicyOption(stringResource(R.string.settings_floating_size_small),
-            effective == FloatingSize.SMALL) { onSelect(FloatingSize.SMALL) }
-        PolicyOption(stringResource(R.string.settings_floating_size_standard),
-            effective == FloatingSize.STANDARD) { onSelect(FloatingSize.STANDARD) }
-        PolicyOption(stringResource(R.string.settings_floating_size_large),
-            effective == FloatingSize.LARGE) { onSelect(FloatingSize.LARGE) }
-    }
+    val effective = if (current == FloatingSize.UNRECOGNIZED) FloatingSize.STANDARD else current
+    DropdownPickerRow(
+        title = stringResource(R.string.settings_floating_size),
+        current = effective,
+        options = listOf(
+            stringResource(R.string.settings_floating_size_small) to FloatingSize.SMALL,
+            stringResource(R.string.settings_floating_size_standard) to FloatingSize.STANDARD,
+            stringResource(R.string.settings_floating_size_large) to FloatingSize.LARGE
+        ),
+        onSelect = onSelect
+    )
 }
 
 // ============ 悬浮球图标 ============

--- a/app/src/main/java/io/mo/glassmic/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/io/mo/glassmic/ui/settings/SettingsScreen.kt
@@ -56,6 +56,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import io.mo.glassmic.BuildConfig
 import io.mo.glassmic.R
 import io.mo.glassmic.data.diag.AudioPipelineProbe
+import io.mo.glassmic.proto.AppLanguage
 import io.mo.glassmic.proto.FloatingSize
 import io.mo.glassmic.proto.LogLevel
 import io.mo.glassmic.proto.PlaybackPolicy
@@ -150,6 +151,7 @@ fun SettingsScreen(
 
             item { Section(stringResource(R.string.settings_section_appearance)) {
                 ThemePicker(cfg.appearance.theme, vm::setTheme)
+                LanguagePicker(cfg.appearance.language, vm::setLanguage)
             } }
 
             item { Section(stringResource(R.string.settings_section_floating)) {
@@ -451,6 +453,24 @@ private fun ThemePicker(current: ThemeMode, onSelect: (ThemeMode) -> Unit) {
             current == ThemeMode.LIGHT) { onSelect(ThemeMode.LIGHT) }
         PolicyOption(stringResource(R.string.settings_theme_dark),
             current == ThemeMode.DARK) { onSelect(ThemeMode.DARK) }
+    }
+}
+
+// ============ 语言 ============
+@Composable
+private fun LanguagePicker(current: AppLanguage, onSelect: (AppLanguage) -> Unit) {
+    Column {
+        Text(
+            stringResource(R.string.settings_language),
+            style = MaterialTheme.typography.bodyLarge,
+            modifier = Modifier.padding(start = 16.dp, top = 12.dp, end = 16.dp)
+        )
+        PolicyOption(stringResource(R.string.settings_language_follow),
+            current == AppLanguage.SYSTEM) { onSelect(AppLanguage.SYSTEM) }
+        PolicyOption(stringResource(R.string.settings_language_zh),
+            current == AppLanguage.ZH) { onSelect(AppLanguage.ZH) }
+        PolicyOption(stringResource(R.string.settings_language_en),
+            current == AppLanguage.EN) { onSelect(AppLanguage.EN) }
     }
 }
 

--- a/app/src/main/java/io/mo/glassmic/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/io/mo/glassmic/ui/settings/SettingsViewModel.kt
@@ -131,11 +131,16 @@ class SettingsViewModel @Inject constructor(
         configStore.update { it.setAppearance(it.appearance.toBuilder().setReduceMotion(reduce)) }
     }
 
-    fun setLanguage(language: AppLanguage) = viewModelScope.launch {
-        configStore.update {
-            it.setAppearance(it.appearance.toBuilder().setLanguage(language).setLanguageResolved(true))
+    fun setLanguage(language: AppLanguage) {
+        // 同步执行：调用方（设置页）选完语言后会立即 recreate() 让改动马上生效，
+        // 必须保证 SharedPreferences 缓存 + AppCompatDelegate 的语言在 recreate() 之前就已写入，
+        // 否则会因为协程还没跑到这里而导致第一次点击"没反应"，要点第二次才生效。
+        AppLocale.apply(context, language)
+        viewModelScope.launch {
+            configStore.update {
+                it.setAppearance(it.appearance.toBuilder().setLanguage(language).setLanguageResolved(true))
+            }
         }
-        AppLocale.apply(language)
     }
 
     // ============ 悬浮窗 ============

--- a/app/src/main/java/io/mo/glassmic/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/io/mo/glassmic/ui/settings/SettingsViewModel.kt
@@ -17,7 +17,9 @@ import io.mo.glassmic.data.runtime.HookStatusRepository
 import io.mo.glassmic.data.runtime.VisibilityCompatRepository
 import kotlinx.coroutines.flow.asStateFlow
 import io.mo.glassmic.log.GlassLog
+import io.mo.glassmic.data.config.AppLocale
 import io.mo.glassmic.proto.AppConfig
+import io.mo.glassmic.proto.AppLanguage
 import io.mo.glassmic.proto.FloatingSize
 import io.mo.glassmic.proto.LogLevel
 import io.mo.glassmic.proto.PlaybackPolicy
@@ -127,6 +129,13 @@ class SettingsViewModel @Inject constructor(
 
     fun setReduceMotion(reduce: Boolean) = viewModelScope.launch {
         configStore.update { it.setAppearance(it.appearance.toBuilder().setReduceMotion(reduce)) }
+    }
+
+    fun setLanguage(language: AppLanguage) = viewModelScope.launch {
+        configStore.update {
+            it.setAppearance(it.appearance.toBuilder().setLanguage(language).setLanguageResolved(true))
+        }
+        AppLocale.apply(language)
     }
 
     // ============ 悬浮窗 ============

--- a/app/src/main/proto/app_config.proto
+++ b/app/src/main/proto/app_config.proto
@@ -112,12 +112,22 @@ message Appearance {
   ThemeMode theme = 1;
   bool glass_effect = 2;
   bool reduce_motion = 3;
+
+  AppLanguage language = 4;
+  // false 时启动逻辑会按系统语言自动写入 language 并置为 true，此后不再自动改写。
+  bool language_resolved = 5;
 }
 
 enum ThemeMode {
   FOLLOW_SYSTEM = 0;
   LIGHT = 1;
   DARK = 2;
+}
+
+enum AppLanguage {
+  SYSTEM = 0;
+  ZH = 1;
+  EN = 2;
 }
 
 message Logging {

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -1,0 +1,203 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- App basics -->
+    <string name="app_name">GlassMic</string>
+    <string name="xposed_description">GlassMic - Virtual Microphone Testing Module</string>
+
+    <!-- Persistent notification (cannot be hidden) -->
+    <string name="notif_channel_name">Virtual Microphone Status</string>
+    <string name="notif_channel_desc">Persistent notification showing the virtual microphone\'s running status. It cannot be hidden while active.</string>
+    <string name="notif_title">GlassMic</string>
+    <string name="notif_text">Virtual microphone in use</string>
+
+    <!-- First launch -->
+    <string name="onboarding_disclaimer_title">Disclaimer</string>
+    <string name="onboarding_disclaimer_body">
+        GlassMic is an open-source virtual microphone and audio pipeline testing tool for Root and LSPosed users.\n\n
+        This tool is intended only for audio pipeline testing, development debugging, compatibility verification, and other legitimate assistive scenarios on your own device. Once enabled, the module shows a persistent notification, and the virtual microphone is turned off by default after a device reboot.\n\n
+        Do not use this tool to impersonate others, deceive calls, harass others, evade platform rules, invade privacy, or engage in any other illegal or non-compliant scenario. Consequences resulting from improper use are the sole responsibility of the user.\n\n
+        Experimental features are for local audio testing only. Do not use them to produce harsh sounds, harass others, or disrupt anyone else\'s normal usage experience.
+    </string>
+    <string name="onboarding_disclaimer_agree">I have read and understood the above, and I commit to using this tool only in legal, transparent, and controlled scenarios.</string>
+    <string name="onboarding_continue">Continue</string>
+    <string name="onboarding_retry">Retry Detection</string>
+    <string name="onboarding_grant">Grant</string>
+
+    <string name="perm_root_title">Root Access</string>
+    <string name="perm_root_hint">Grant GlassMic root access in your Magisk / KernelSU manager.</string>
+    <string name="perm_notif_title">Notification Permission</string>
+    <string name="perm_notif_hint">A persistent notification is required while the virtual microphone is on. Core functionality is unavailable if notifications are disabled.</string>
+    <string name="perm_overlay_title">Overlay Permission</string>
+    <string name="perm_overlay_hint">Used to show the floating control window. Falls back to notification + main screen controls if not granted.</string>
+    <string name="perm_file_title">Audio File Access</string>
+    <string name="perm_file_hint">Used to import and read the local audio files you select.</string>
+    <string name="perm_fgs_title">Foreground Service</string>
+    <string name="perm_fgs_hint">Used to keep the service running and show the persistent notification.</string>
+    <string name="perm_safemode_title">Safe Mode Status</string>
+    <string name="perm_safemode_hint">Detects whether the last session exited abnormally.</string>
+
+    <!-- Status -->
+    <string name="status_running">GlassMic is running</string>
+    <string name="status_off">GlassMic is off</string>
+    <string name="status_using_real">Currently using the real microphone</string>
+    <string name="status_using_virtual">Virtual microphone in use</string>
+
+    <!-- Quick Settings tile -->
+    <string name="tile_label">GlassMic</string>
+
+    <!-- Home -->
+    <string name="home_pick_audio">Choose Audio</string>
+    <string name="home_open_floating">Open Floating Window</string>
+    <string name="home_restore_mic">Restore Real Microphone</string>
+    <string name="home_field_source">Source</string>
+    <string name="home_field_group">Clip Group</string>
+    <string name="home_field_policy">Policy</string>
+    <string name="home_field_scope">Scope</string>
+    <string name="home_field_floating">Floating Window</string>
+    <string name="home_field_hook">Xposed Hook</string>
+    <string name="home_field_intercept">Intercept Stats</string>
+    <string name="hook_status_never">Not detected (make sure the module is enabled and the device has been rebooted)</string>
+    <string name="hook_status_active">Active</string>
+    <string name="hook_status_stale">Loaded (no recent recording events)</string>
+    <string name="intercept_none">No AudioRecord calls intercepted yet</string>
+    <string name="intercept_summary">Intercepted %1$d times / %2$s</string>
+
+    <!-- Safe mode -->
+    <string name="safe_mode_title">GlassMic has entered Safe Mode</string>
+    <string name="safe_mode_subtitle">Virtual microphone functionality has been stopped</string>
+    <string name="safe_mode_exit">Exit Safe Mode</string>
+    <string name="safe_mode_export_diag">Export Diagnostic Bundle</string>
+    <string name="safe_mode_exit_confirm">After exiting Safe Mode, you can turn GlassMic back on. If the issue recurs, please export a diagnostic bundle and report it.</string>
+
+    <!-- Scope -->
+    <string name="scope_title">Effective Scope</string>
+    <string name="scope_mode_global">System-wide</string>
+    <string name="scope_mode_global_hint">Applies to all apps within scope (no package filtering)</string>
+    <string name="scope_mode_whitelist">Whitelist</string>
+    <string name="scope_mode_whitelist_hint">Only applies to apps checked in the list</string>
+    <string name="scope_native_warn">Note: the module can only hook into app processes within LSPosed\'s scope; native daemons like audioserver and apps that use NDK AAudio directly are not covered.</string>
+    <string name="scope_lsposed_alert_title">⚠️ This sets in-app filtering, not the LSPosed injection switch</string>
+    <string name="scope_lsposed_alert_body">Whether you choose "System-wide" or "Whitelist" here, the module **must first be injected by LSPosed into the target app\'s process** to take effect.\n\nIf you find apps like WeChat / TikTok have no effect:\n1. Open "LSPosed Manager"\n2. Modules → GlassMic → Scope\n3. Check the app you want to hook\n4. Force-stop that app and reopen it</string>
+    <string name="scope_open_lsposed">Open LSPosed Manager</string>
+    <string name="scope_open_lsposed_failed">LSPosed Manager not found</string>
+    <string name="scope_show_system_apps">Show System Apps</string>
+    <string name="scope_search_hint">Search app name or package</string>
+    <string name="scope_loading">Loading installed apps…</string>
+    <string name="scope_empty">No matching apps</string>
+    <string name="scope_selected_count">%d selected</string>
+
+    <!-- Audio library -->
+    <string name="library_title">Audio Library</string>
+    <string name="library_import">Import Audio</string>
+    <string name="library_new_group">New Clip Group</string>
+    <string name="library_empty_groups">No clip groups yet — create one first</string>
+    <string name="library_empty_clips">This group has no audio yet. Tap the button below to import</string>
+    <string name="library_select_a_group">Select or create a clip group first</string>
+    <string name="library_preview">Preview</string>
+    <string name="library_preview_stop">Stop Preview</string>
+    <string name="library_delete">Delete</string>
+    <string name="library_rename">Rename</string>
+    <string name="library_change_emoji">Change Icon</string>
+    <string name="library_change_policy">Change Playback Policy</string>
+    <string name="library_policy_follow_global">Follow Global</string>
+    <string name="library_policy_silence">Silence After Playback</string>
+    <string name="library_policy_loop">Loop</string>
+    <string name="library_policy_real_mic">Switch Back to Real Mic</string>
+    <string name="library_group_name_hint">Clip group name</string>
+    <string name="library_clip_name_hint">Audio name</string>
+    <string name="library_delete_group_confirm">Deleting this group will also delete all audio in it. Continue?</string>
+    <string name="library_delete_clip_confirm">Delete this audio?</string>
+    <string name="library_cancel">Cancel</string>
+    <string name="library_confirm">Confirm</string>
+    <string name="library_current_marker">Current Source</string>
+    <string name="library_import_failed">Import failed</string>
+
+    <!-- Settings -->
+    <string name="settings_title">Settings</string>
+    <string name="settings_section_appearance">Appearance</string>
+    <string name="settings_theme">Theme</string>
+    <string name="settings_theme_follow">Follow System</string>
+    <string name="settings_theme_light">Light</string>
+    <string name="settings_theme_dark">Dark</string>
+    <string name="settings_language">Language</string>
+    <string name="settings_language_follow">Follow System</string>
+    <string name="settings_language_zh">简体中文</string>
+    <string name="settings_language_en">English</string>
+    <string name="settings_glass_effect">Liquid Glass</string>
+    <string name="settings_glass_effect_hint">Turn off to reduce power usage</string>
+    <string name="settings_reduce_motion">Reduce Motion</string>
+
+    <string name="settings_section_tile">Quick Settings Tile</string>
+    <string name="settings_tile_add">Add to Quick Settings</string>
+    <string name="settings_tile_add_hint">Add the GlassMic toggle tile to the system quick settings panel</string>
+    <string name="settings_tile_added">Tile added</string>
+
+    <string name="settings_section_floating">Floating Window</string>
+    <string name="settings_floating_enabled">Allow Floating Window</string>
+    <string name="settings_floating_enabled_hint">Only shows once the main switch is on</string>
+    <string name="settings_floating_opacity">Opacity</string>
+    <string name="settings_floating_size">Floating Ball Size</string>
+    <string name="settings_floating_size_small">Small</string>
+    <string name="settings_floating_size_standard">Standard</string>
+    <string name="settings_floating_size_large">Large</string>
+    <string name="settings_floating_icon">Floating Ball Icon</string>
+    <string name="settings_floating_icon_hint">Customize the floating ball icon; leave empty to use the default</string>
+    <string name="settings_floating_icon_pick">Choose Image</string>
+    <string name="settings_floating_icon_reset">Reset to Default</string>
+    <string name="settings_floating_icon_error">Icon import failed</string>
+    <string name="settings_waveform_enabled">Live Waveform Display</string>
+    <string name="settings_waveform_enabled_hint">Shows a separate live waveform floating window when enabled</string>
+    <string name="settings_waveform_opacity">Waveform Opacity</string>
+
+    <string name="settings_section_policy">Default Playback Policy</string>
+    <string name="settings_policy_hint">Used when a clip group has no policy of its own</string>
+
+    <string name="settings_section_hook">Xposed Hook Status</string>
+    <string name="settings_hook_refresh">Refresh</string>
+    <string name="settings_hook_never_long">No app has triggered GlassMic\'s recording hook yet. Please confirm:\n1) The module is enabled in LSPosed\n2) The device has been rebooted\n3) The test app is within LSPosed\'s scope</string>
+    <string name="settings_hook_active_long">An app triggered the recording hook within the last 5 minutes — the hook is working normally.</string>
+    <string name="settings_hook_stale_long">The recording hook has been triggered before, but there have been no new events in the last 5 minutes. The module may still be loaded — no app is recording right now.</string>
+
+    <string name="settings_section_diag">Diagnostics &amp; Logs</string>
+    <string name="settings_log_level">Log Level</string>
+    <string name="settings_log_off">Off</string>
+    <string name="settings_log_basic">Basic</string>
+    <string name="settings_log_verbose">Verbose</string>
+    <string name="settings_log_debug">Debug</string>
+    <string name="settings_export_diag">Export Diagnostic Bundle</string>
+    <string name="settings_clear_log">Clear In-Memory Log</string>
+    <string name="settings_pipeline_probe">Test Audio Pipeline (Local)</string>
+    <string name="settings_pipeline_probe_hint">Opens the PCM channel locally for 1 second to check whether the app-side pipeline works</string>
+    <string name="settings_section_intercept">Intercept Stats</string>
+    <string name="settings_intercept_reset">Reset</string>
+    <string name="settings_intercept_total_reads">Times Intercepted</string>
+    <string name="settings_intercept_total_bytes">Bytes Intercepted</string>
+    <string name="settings_intercept_last">Last Intercept Time</string>
+    <string name="settings_intercept_last_pkg">Last Caller</string>
+    <string name="settings_intercept_format">Sample Rate / Channels</string>
+
+    <string name="settings_section_compat">Compatibility</string>
+    <string name="settings_visibility_compat">Strict ROM Compatibility Mode</string>
+    <string name="settings_visibility_compat_hint">Enable this if the module has no effect. It will request root access and takes effect after rebooting once granted.</string>
+
+    <string name="settings_section_experimental">Experimental Features</string>
+    <string name="settings_experimental_unlock">Unlock Experimental Features</string>
+    <string name="settings_experimental_unlock_hint">For local audio pipeline testing only</string>
+    <string name="settings_exp_stress">Audio Stress Test</string>
+    <string name="settings_exp_high_gain">High Gain</string>
+    <string name="settings_exp_noise">Noise Environment Simulation</string>
+    <string name="settings_exp_limiter">Auto Limiter Protection</string>
+    <string name="settings_exp_limiter_hint">Turning this off may cause clipping — strongly recommended to keep it on</string>
+    <string name="settings_exp_reverb">Reverb</string>
+    <string name="settings_exp_reverb_hint">Adds spatial echo on top of the audio source</string>
+    <string name="settings_exp_reverb_amount">Reverb Intensity</string>
+    <string name="settings_exp_speed">Speed Change</string>
+    <string name="settings_exp_speed_hint">Changes the playback speed</string>
+    <string name="settings_exp_speed_factor">Playback Speed</string>
+
+    <string name="settings_section_about">About</string>
+    <string name="settings_about_version">Version</string>
+    <string name="settings_about_license">License</string>
+    <string name="settings_about_repo">Repository</string>
+
+</resources>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -61,6 +61,11 @@
     <string name="hook_status_stale">Loaded (no recent recording events)</string>
     <string name="intercept_none">No AudioRecord calls intercepted yet</string>
     <string name="intercept_summary">Intercepted %1$d times / %2$s</string>
+    <string name="source_real_mic">Real Microphone</string>
+    <string name="source_silence">Silence</string>
+    <string name="source_tts">Text-to-Speech</string>
+    <string name="home_policy_silence">Silence</string>
+    <string name="home_scope_whitelist_count">Whitelist (%1$d)</string>
 
     <!-- Safe mode -->
     <string name="safe_mode_title">GlassMic has entered Safe Mode</string>
@@ -199,5 +204,80 @@
     <string name="settings_about_version">Version</string>
     <string name="settings_about_license">License</string>
     <string name="settings_about_repo">Repository</string>
+
+    <!-- Common -->
+    <string name="common_back">Back</string>
+
+    <!-- Settings → Speech Synthesis -->
+    <string name="settings_section_ai_tts">Speech Synthesis</string>
+    <string name="ai_tts_title">AI Provider (TTS)</string>
+    <string name="ai_tts_nav_enabled">Enabled · %1$s</string>
+    <string name="ai_tts_nav_disabled">Using system TTS (tap to configure online AI)</string>
+
+    <!-- AI Provider (TTS) settings page -->
+    <string name="ai_tts_section_access">Access</string>
+    <string name="ai_tts_enable">Enable AI TTS</string>
+    <string name="ai_tts_protocol">Protocol</string>
+    <string name="ai_tts_provider_openai">OpenAI (/audio/speech)</string>
+    <string name="ai_tts_provider_gemini">Google Gemini (generateContent)</string>
+    <string name="ai_tts_provider_mimo">Xiaomi MiMo (chat/completions)</string>
+    <string name="ai_tts_section_endpoint">Endpoint</string>
+    <string name="ai_tts_endpoint_hint">Custom endpoint (leave empty for the official default)</string>
+    <string name="ai_tts_api_key">API Key</string>
+    <string name="ai_tts_model_hint">Custom model (leave empty for the default)</string>
+    <string name="ai_tts_fetch_models">Fetch Models</string>
+    <string name="ai_tts_fetching_models">Fetching…</string>
+    <string name="ai_tts_models_count">%1$d total — tap to reselect</string>
+    <string name="ai_tts_section_voice">Voice</string>
+    <string name="ai_tts_voice_hint">Voice (preset / OpenAI / Gemini)</string>
+    <string name="ai_tts_mimo_advanced">MiMo advanced: set the model to -voicedesign to customize a voice via text description (write it in the description box below); set it to -voiceclone to clone a voice (pick a ≤60s, ≤5MB reference sample).</string>
+    <string name="ai_tts_style_prompt_hint">Voice description / style (required for voicedesign, optional for preset)</string>
+    <string name="ai_tts_clone_sample">Reference Audio (voiceclone)</string>
+    <string name="ai_tts_clone_sample_selected">Sample selected (≤60s / ≤5MB)</string>
+    <string name="ai_tts_clone_sample_none">Not selected — voice cloning needs a reference audio sample first</string>
+    <string name="ai_tts_clear">Clear</string>
+    <string name="ai_tts_choose_audio">Choose Audio</string>
+    <string name="ai_tts_format_hint">Response format (OpenAI: wav / pcm)</string>
+    <string name="ai_tts_section_test">Test &amp; Preview</string>
+    <string name="ai_tts_test_connection">Test Connection</string>
+    <string name="ai_tts_testing">Testing…</string>
+    <string name="ai_tts_preview_text_label">Preview Text</string>
+    <string name="ai_tts_preview_default_text">Hello, this is a sample text for preview.</string>
+    <string name="ai_tts_generate">Generate</string>
+    <string name="ai_tts_generating">Generating…</string>
+    <string name="ai_tts_preview_play">Preview</string>
+    <string name="ai_tts_preview_playing">Playing…</string>
+    <string name="ai_tts_save_audio">Save Audio</string>
+
+    <!-- AI Provider (TTS) dynamic messages -->
+    <string name="ai_tts_connected_ok">Connected successfully, received %1$d KB of audio</string>
+    <string name="ai_tts_test_timeout">Test timed out (25s)</string>
+    <string name="ai_tts_test_phrase">This is a connection test.</string>
+    <string name="ai_tts_no_models_returned">The endpoint returned no models</string>
+    <string name="ai_tts_fetch_models_failed">Fetch failed</string>
+    <string name="ai_tts_enter_preview_text">Enter preview text first</string>
+    <string name="ai_tts_no_audio_received">No audio received</string>
+    <string name="ai_tts_generate_first">Tap "Generate" first</string>
+    <string name="ai_tts_generate_audio_first">Generate audio first</string>
+    <string name="ai_tts_saved">Audio saved</string>
+    <string name="ai_tts_save_failed">Save failed</string>
+
+    <!-- Floating window content (runtime UI, not a settings screen) -->
+    <string name="float_change_source">Change Source</string>
+    <string name="float_collapse">Collapse</string>
+    <string name="float_back">Back</string>
+    <string name="float_no_groups">No clip groups yet</string>
+    <string name="float_no_clips_in_group">This group has no audio yet</string>
+    <string name="float_tts_entry">🗣  Text-to-Speech (TTS)</string>
+    <string name="float_current">Current</string>
+    <string name="float_tts_title">🗣 Text-to-Speech</string>
+    <string name="float_settings">Settings</string>
+    <string name="float_tts_input_hint">Enter text to synthesize, generate before playing</string>
+    <string name="float_tts_generating">Generating…</string>
+    <string name="float_tts_generate">Generate</string>
+    <string name="float_tts_play">Play</string>
+    <string name="float_tts_generate_failed">Generation failed. Check your network or TTS engine and try again</string>
+    <string name="float_tts_settings_title">Text-to-Speech Settings</string>
+    <string name="float_tts_progress_bar">Playback Progress Bar</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -61,6 +61,11 @@
     <string name="hook_status_stale">已加载（无近期录音事件）</string>
     <string name="intercept_none">还没拦截到任何 AudioRecord 调用</string>
     <string name="intercept_summary">已劫持 %1$d 次 / %2$s</string>
+    <string name="source_real_mic">真实麦克风</string>
+    <string name="source_silence">静音</string>
+    <string name="source_tts">文字转语音</string>
+    <string name="home_policy_silence">静音</string>
+    <string name="home_scope_whitelist_count">白名单（%1$d）</string>
 
     <!-- 安全模式 -->
     <string name="safe_mode_title">GlassMic 已进入安全模式</string>
@@ -199,5 +204,80 @@
     <string name="settings_about_version">版本</string>
     <string name="settings_about_license">开源协议</string>
     <string name="settings_about_repo">项目仓库</string>
+
+    <!-- 通用 -->
+    <string name="common_back">返回</string>
+
+    <!-- 设置页 → 语音合成 -->
+    <string name="settings_section_ai_tts">语音合成</string>
+    <string name="ai_tts_title">AI 供应商（TTS）</string>
+    <string name="ai_tts_nav_enabled">已启用 · %1$s</string>
+    <string name="ai_tts_nav_disabled">使用系统 TTS（点击配置在线 AI）</string>
+
+    <!-- AI 供应商（TTS）配置页 -->
+    <string name="ai_tts_section_access">接入</string>
+    <string name="ai_tts_enable">启用 AI TTS</string>
+    <string name="ai_tts_protocol">接口协议</string>
+    <string name="ai_tts_provider_openai">OpenAI（/audio/speech）</string>
+    <string name="ai_tts_provider_gemini">Google Gemini（generateContent）</string>
+    <string name="ai_tts_provider_mimo">小米 MiMo（chat/completions）</string>
+    <string name="ai_tts_section_endpoint">接口</string>
+    <string name="ai_tts_endpoint_hint">自定义地址 endpoint（留空用官方默认）</string>
+    <string name="ai_tts_api_key">API Key</string>
+    <string name="ai_tts_model_hint">自定义模型 model（留空用默认）</string>
+    <string name="ai_tts_fetch_models">获取模型</string>
+    <string name="ai_tts_fetching_models">获取中…</string>
+    <string name="ai_tts_models_count">共 %1$d 个，点此重选</string>
+    <string name="ai_tts_section_voice">音色</string>
+    <string name="ai_tts_voice_hint">音色 voice（preset / OpenAI / Gemini）</string>
+    <string name="ai_tts_mimo_advanced">MiMo 进阶：模型填 -voicedesign 用文本描述定制音色（写在下方描述框）；填 -voiceclone 复刻音色（选一段 ≤60 秒、≤5MB 的参考音频）。</string>
+    <string name="ai_tts_style_prompt_hint">音色描述 / 风格（voicedesign 必填，preset 可选）</string>
+    <string name="ai_tts_clone_sample">参考音频（voiceclone）</string>
+    <string name="ai_tts_clone_sample_selected">已选择样本（≤60 秒 / ≤5MB）</string>
+    <string name="ai_tts_clone_sample_none">未选择——复刻音色需先选一段音频样本</string>
+    <string name="ai_tts_clear">清除</string>
+    <string name="ai_tts_choose_audio">选择音频</string>
+    <string name="ai_tts_format_hint">返回格式 format（OpenAI：wav / pcm）</string>
+    <string name="ai_tts_section_test">测试与试听</string>
+    <string name="ai_tts_test_connection">测试连接</string>
+    <string name="ai_tts_testing">测试中…</string>
+    <string name="ai_tts_preview_text_label">试听文本</string>
+    <string name="ai_tts_preview_default_text">你好，这是一段用于试听的示例文本。</string>
+    <string name="ai_tts_generate">生成</string>
+    <string name="ai_tts_generating">生成中…</string>
+    <string name="ai_tts_preview_play">效果试听</string>
+    <string name="ai_tts_preview_playing">播放中…</string>
+    <string name="ai_tts_save_audio">保存音频</string>
+
+    <!-- AI 供应商（TTS）动态消息 -->
+    <string name="ai_tts_connected_ok">连接成功，收到 %1$d KB 音频</string>
+    <string name="ai_tts_test_timeout">测试超时（25 秒）</string>
+    <string name="ai_tts_test_phrase">这是一段连接测试。</string>
+    <string name="ai_tts_no_models_returned">接口未返回模型</string>
+    <string name="ai_tts_fetch_models_failed">获取失败</string>
+    <string name="ai_tts_enter_preview_text">请先输入试听文本</string>
+    <string name="ai_tts_no_audio_received">未获取到音频</string>
+    <string name="ai_tts_generate_first">请先点「生成」</string>
+    <string name="ai_tts_generate_audio_first">请先生成音频</string>
+    <string name="ai_tts_saved">已保存音频</string>
+    <string name="ai_tts_save_failed">保存失败</string>
+
+    <!-- 悬浮窗内容（运行时 UI，非设置项） -->
+    <string name="float_change_source">换音源</string>
+    <string name="float_collapse">收起</string>
+    <string name="float_back">返回</string>
+    <string name="float_no_groups">还没有音频分组</string>
+    <string name="float_no_clips_in_group">该分组还没有音频</string>
+    <string name="float_tts_entry">🗣  文字转语音（TTS）</string>
+    <string name="float_current">当前</string>
+    <string name="float_tts_title">🗣 文字转语音</string>
+    <string name="float_settings">设置</string>
+    <string name="float_tts_input_hint">输入要合成的文字，先生成再播放</string>
+    <string name="float_tts_generating">生成中…</string>
+    <string name="float_tts_generate">生成</string>
+    <string name="float_tts_play">播放</string>
+    <string name="float_tts_generate_failed">生成失败，请检查网络或 TTS 引擎后重试</string>
+    <string name="float_tts_settings_title">文字转语音设置</string>
+    <string name="float_tts_progress_bar">播放进度条</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -119,6 +119,10 @@
     <string name="settings_theme_follow">跟随系统</string>
     <string name="settings_theme_light">浅色</string>
     <string name="settings_theme_dark">深色</string>
+    <string name="settings_language">语言</string>
+    <string name="settings_language_follow">跟随系统</string>
+    <string name="settings_language_zh">简体中文</string>
+    <string name="settings_language_en">English</string>
     <string name="settings_glass_effect">液态玻璃</string>
     <string name="settings_glass_effect_hint">关闭可降低功耗</string>
     <string name="settings_reduce_motion">减少动画</string>

--- a/app/src/main/res/xml/locales_config.xml
+++ b/app/src/main/res/xml/locales_config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<locale-config xmlns:android="http://schemas.android.com/apk/res/android">
+    <locale android:name="zh-CN" />
+    <locale android:name="en" />
+</locale-config>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,6 +18,7 @@ documentfile = "1.0.1"
 [libraries]
 # AndroidX 基础
 androidx-core-ktx = { module = "androidx.core:core-ktx", version = "1.15.0" }
+androidx-appcompat = { module = "androidx.appcompat:appcompat", version = "1.7.0" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version = "1.9.3" }
 androidx-lifecycle-runtime-ktx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "lifecycle" }
 androidx-lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "lifecycle" }


### PR DESCRIPTION
Add values-en/strings.xml with full English translations, plus a
Language picker in Settings > Appearance (跟随系统/简体中文/English).
On first launch the app auto-selects Chinese or English based on the
system locale (persisted in AppConfig.appearance so it only runs once).
Uses AppCompatDelegate.setApplicationLocales for per-app language on
top of a ComponentActivity-based Compose UI.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DQjtubVS1A9sj2mbKmcu9u