### PR TITLE
Debug

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,7 +16,7 @@ android {
         minSdk = 29
         targetSdk = 35
         versionCode = 16
-        versionName = "1.3.4.2"
+        versionName = "1.3.4.6"
         resourceConfigurations += listOf("zh-rCN", "en")
     }
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,7 +16,7 @@ android {
         minSdk = 29
         targetSdk = 35
         versionCode = 16
-        versionName = "1.3.4.6"
+        versionName = "1.3.4.7"
         resourceConfigurations += listOf("zh-rCN", "en")
     }
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,7 +16,7 @@ android {
         minSdk = 29
         targetSdk = 35
         versionCode = 16
-        versionName = "1.3.4"
+        versionName = "1.3.4.2"
         resourceConfigurations += listOf("zh-rCN", "en")
     }
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,7 +16,7 @@ android {
         minSdk = 29
         targetSdk = 35
         versionCode = 16
-        versionName = "1.3.4.7"
+        versionName = "1.3.5"
         resourceConfigurations += listOf("zh-rCN", "en")
     }
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,6 +8,8 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" />
     <!-- 无 RECORD_AUDIO 时前台服务降级到 specialUse 类型，需要此权限 -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
+    <!-- 音频推流防 CPU 睡眠唤醒锁 -->
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
 
     <!-- 通知 -->
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />

--- a/app/src/main/java/io/mo/glassmic/audio/AudioMonitorPlayer.kt
+++ b/app/src/main/java/io/mo/glassmic/audio/AudioMonitorPlayer.kt
@@ -1,0 +1,167 @@
+package io.mo.glassmic.audio
+
+import android.media.AudioAttributes
+import android.media.AudioFormat
+import android.media.AudioManager
+import android.media.AudioTrack
+import android.os.Build
+import io.mo.glassmic.log.GlassLog
+import java.util.concurrent.atomic.AtomicBoolean
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * 实时耳返 / 本地监听播放器。
+ *
+ * 当虚拟麦克风向目标应用推流时，同步把主格式（48kHz 单声道 PCM16）音频写入 AudioTrack，
+ * 让用户通过扬声器或耳机实时听到当前替换的音源内容与进度。
+ */
+@Singleton
+class AudioMonitorPlayer @Inject constructor() {
+
+    private var audioTrack: AudioTrack? = null
+    @Volatile private var isEnabled: Boolean = false
+    @Volatile private var volume: Float = 1.0f
+    private val isPlaying = AtomicBoolean(false)
+
+    private companion object {
+        const val SAMPLE_RATE = 48_000
+        const val CHANNEL_CONFIG = AudioFormat.CHANNEL_OUT_MONO
+        const val AUDIO_FORMAT = AudioFormat.ENCODING_PCM_16BIT
+    }
+
+    @Synchronized
+    fun setEnabled(enabled: Boolean) {
+        if (isEnabled == enabled) return
+        isEnabled = enabled
+        if (!enabled) {
+            pauseAndFlush()
+        }
+    }
+
+    @Synchronized
+    fun setVolume(vol: Float) {
+        val clamped = vol.coerceIn(0f, 1f)
+        volume = clamped
+        audioTrack?.let { track ->
+            runCatching {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                    track.setVolume(clamped)
+                } else {
+                    @Suppress("DEPRECATION")
+                    track.setStereoVolume(clamped, clamped)
+                }
+            }
+        }
+    }
+
+    /**
+     * 写入一帧 PCM16 数据并播放。
+     * 如果未开启耳返，则直接跳过，零开销。
+     */
+    fun write(data: ByteArray) {
+        if (!isEnabled || data.isEmpty()) return
+        val track = getOrCreateTrack() ?: return
+        try {
+            if (!isPlaying.get()) {
+                if (track.playState != AudioTrack.PLAYSTATE_PLAYING) {
+                    track.play()
+                }
+                isPlaying.set(true)
+            }
+            track.write(data, 0, data.size, AudioTrack.WRITE_NON_BLOCKING)
+        } catch (t: Throwable) {
+            GlassLog.b("AudioMonitor") { "write 异常: ${t.message}" }
+        }
+    }
+
+    /**
+     * 暂停并清空缓冲区（目标应用停止录音、暂停或切换音源时调用）。
+     */
+    @Synchronized
+    fun pauseAndFlush() {
+        if (isPlaying.compareAndSet(true, false)) {
+            runCatching {
+                audioTrack?.let { track ->
+                    if (track.playState == AudioTrack.PLAYSTATE_PLAYING) {
+                        track.pause()
+                    }
+                    track.flush()
+                }
+            }
+        }
+    }
+
+    @Synchronized
+    private fun getOrCreateTrack(): AudioTrack? {
+        if (audioTrack != null && audioTrack?.state == AudioTrack.STATE_INITIALIZED) {
+            return audioTrack
+        }
+        release()
+        return try {
+            val minBuf = AudioTrack.getMinBufferSize(SAMPLE_RATE, CHANNEL_CONFIG, AUDIO_FORMAT)
+            val bufSize = (minBuf * 2).coerceAtLeast(1920 * 2)
+
+            val track = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                AudioTrack.Builder()
+                    .setAudioAttributes(
+                        AudioAttributes.Builder()
+                            .setUsage(AudioAttributes.USAGE_MEDIA)
+                            .setContentType(AudioAttributes.CONTENT_TYPE_MUSIC)
+                            .build()
+                    )
+                    .setAudioFormat(
+                        AudioFormat.Builder()
+                            .setSampleRate(SAMPLE_RATE)
+                            .setChannelMask(CHANNEL_CONFIG)
+                            .setEncoding(AUDIO_FORMAT)
+                            .build()
+                    )
+                    .setBufferSizeInBytes(bufSize)
+                    .setTransferMode(AudioTrack.MODE_STREAM)
+                    .build()
+            } else {
+                @Suppress("DEPRECATION")
+                AudioTrack(
+                    AudioManager.STREAM_MUSIC,
+                    SAMPLE_RATE,
+                    CHANNEL_CONFIG,
+                    AUDIO_FORMAT,
+                    bufSize,
+                    AudioTrack.MODE_STREAM
+                )
+            }
+
+            if (track.state == AudioTrack.STATE_INITIALIZED) {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                    track.setVolume(volume)
+                } else {
+                    @Suppress("DEPRECATION")
+                    track.setStereoVolume(volume, volume)
+                }
+                audioTrack = track
+                track
+            } else {
+                track.release()
+                null
+            }
+        } catch (t: Throwable) {
+            GlassLog.b("AudioMonitor") { "AudioTrack 初始化失败: ${t.message}" }
+            null
+        }
+    }
+
+    @Synchronized
+    fun release() {
+        isPlaying.set(false)
+        audioTrack?.let { track ->
+            runCatching {
+                if (track.playState == AudioTrack.PLAYSTATE_PLAYING) {
+                    track.stop()
+                }
+                track.release()
+            }
+        }
+        audioTrack = null
+    }
+}

--- a/app/src/main/java/io/mo/glassmic/audio/FileAudioSource.kt
+++ b/app/src/main/java/io/mo/glassmic/audio/FileAudioSource.kt
@@ -12,11 +12,7 @@ import java.nio.ByteBuffer
 import java.nio.ByteOrder
 
 /**
- * Decodes an imported audio file to signed 16-bit little-endian PCM and converts it to the
- * requested sample rate/channel layout. The conversion is intentionally small and dependency-free:
- * nearest-frame resampling plus channel mix/copy. That is enough to keep voice-recording clients
- * such as WeChat on the correct clock even when they request 16 kHz while the imported file is
- * 44.1/48 kHz.
+ * 将导入的音频文件解码并通过 [Pcm16Converter] 高保真重采样/混音为请求的 PCM 格式。
  */
 class FileAudioSource(
     private val clip: AudioClip,
@@ -38,16 +34,13 @@ class FileAudioSource(
     private var sourceChannels = clip.channels.takeIf { it > 0 } ?: 1
     private var pcmEncoding = PCM_ENCODING_16BIT
 
-    private var pendingSamples = ShortArray(0)
-    private var pendingFrameOffset = 0
-    private var pendingFrameCount = 0
-
-    private var currentFrame = ShortArray(sourceChannels)
-    private var hasCurrentFrame = false
-    private var sourceCursor = 0.0
     private var lastTargetSampleRate = 0
     private var lastTargetChannels = 0
     private var generatedTargetFrames = 0L
+
+    private var converter: Pcm16Converter? = null
+    private var convertedBuffer = ByteArray(0)
+    private var convertedOffset = 0
 
     init {
         extractor.setDataSource(filePath)
@@ -71,99 +64,108 @@ class FileAudioSource(
         val bytesPerTargetFrame = targetChannels * BYTES_PER_SAMPLE
         if (out.remaining() < bytesPerTargetFrame) return 0
 
-        if (targetSampleRate != lastTargetSampleRate || targetChannels != lastTargetChannels) {
-            resetResampler(targetSampleRate, targetChannels)
+        if (targetSampleRate != lastTargetSampleRate || targetChannels != lastTargetChannels || converter == null) {
+            lastTargetSampleRate = targetSampleRate
+            lastTargetChannels = targetChannels
+            converter = Pcm16Converter(
+                sourceSampleRate = sourceSampleRate,
+                sourceChannels = sourceChannels,
+                targetSampleRate = targetSampleRate,
+                targetChannels = targetChannels
+            )
+            convertedBuffer = ByteArray(0)
+            convertedOffset = 0
+            generatedTargetFrames = positionUs * targetSampleRate / 1_000_000L
         }
 
         var written = 0
         while (out.remaining() >= bytesPerTargetFrame) {
-            val frame = nextResampledFrame(targetSampleRate) ?: break
-            writeFrame(out, frame, targetChannels)
-            written += bytesPerTargetFrame
-            generatedTargetFrames++
+            // 如果缓冲区内还有转换好的数据，先输出
+            val availableConverted = convertedBuffer.size - convertedOffset
+            if (availableConverted >= bytesPerTargetFrame) {
+                val framesToTake = minOf(availableConverted / bytesPerTargetFrame, out.remaining() / bytesPerTargetFrame)
+                val bytesToTake = framesToTake * bytesPerTargetFrame
+                out.put(convertedBuffer, convertedOffset, bytesToTake)
+                convertedOffset += bytesToTake
+                written += bytesToTake
+                generatedTargetFrames += framesToTake
+                continue
+            }
+
+            // 缓冲区不足，从解码器读取下一批原始 PCM 数据并转换
+            val rawBytes = loadNextDecodedPcm16Bytes()
+            if (rawBytes != null && rawBytes.isNotEmpty()) {
+                val conv = converter!!.convert(rawBytes)
+                if (conv.isNotEmpty()) {
+                    if (availableConverted > 0) {
+                        val merged = ByteArray(availableConverted + conv.size)
+                        System.arraycopy(convertedBuffer, convertedOffset, merged, 0, availableConverted)
+                        System.arraycopy(conv, 0, merged, availableConverted, conv.size)
+                        convertedBuffer = merged
+                        convertedOffset = 0
+                    } else {
+                        convertedBuffer = conv
+                        convertedOffset = 0
+                    }
+                }
+            } else {
+                // 没有更多解码数据产生
+                break
+            }
         }
 
         if (written > 0) {
             positionUs = generatedTargetFrames * 1_000_000L / targetSampleRate
             written
-        } else if (outputDone && !hasCurrentFrame && pendingFrameOffset >= pendingFrameCount) {
+        } else if (outputDone && (convertedBuffer.size - convertedOffset) < bytesPerTargetFrame) {
             -1
         } else {
             0
         }
     }
 
-    private fun nextResampledFrame(targetSampleRate: Int): ShortArray? {
-        if (!hasCurrentFrame) {
-            currentFrame = readSourceFrame() ?: return null
-            hasCurrentFrame = true
-            sourceCursor = 0.0
-        }
-
-        val out = currentFrame
-        sourceCursor += sourceSampleRate.toDouble() / targetSampleRate.toDouble()
-        while (sourceCursor >= 1.0) {
-            val next = readSourceFrame()
-            if (next == null) {
-                if (outputDone) hasCurrentFrame = false
-                break
-            }
-            currentFrame = next
-            sourceCursor -= 1.0
-        }
-        return out
-    }
-
-    private fun readSourceFrame(): ShortArray? {
-        while (pendingFrameOffset >= pendingFrameCount) {
-            if (!loadNextDecodedBuffer()) return null
-        }
-
-        val frame = ShortArray(sourceChannels)
-        val sampleOffset = pendingFrameOffset * sourceChannels
-        for (i in 0 until sourceChannels) {
-            frame[i] = pendingSamples.getOrElse(sampleOffset + i) { 0 }
-        }
-        pendingFrameOffset++
-        return frame
-    }
-
-    private fun loadNextDecodedBuffer(): Boolean {
-        pendingSamples = ShortArray(0)
-        pendingFrameOffset = 0
-        pendingFrameCount = 0
-
+    private fun loadNextDecodedPcm16Bytes(): ByteArray? {
         while (!outputDone) {
             if (!inputDone) feedInput()
 
             when (val outIdx = codec.dequeueOutputBuffer(info, DEQUEUE_TIMEOUT_US)) {
-                MediaCodec.INFO_TRY_AGAIN_LATER -> return false
+                MediaCodec.INFO_TRY_AGAIN_LATER -> return null
                 MediaCodec.INFO_OUTPUT_FORMAT_CHANGED -> {
                     val fmt = codec.outputFormat
-                    sourceSampleRate = fmt.getIntegerOrDefault(MediaFormat.KEY_SAMPLE_RATE, sourceSampleRate)
-                    sourceChannels = fmt.getIntegerOrDefault(MediaFormat.KEY_CHANNEL_COUNT, sourceChannels)
+                    val newSr = fmt.getIntegerOrDefault(MediaFormat.KEY_SAMPLE_RATE, sourceSampleRate)
+                    val newCh = fmt.getIntegerOrDefault(MediaFormat.KEY_CHANNEL_COUNT, sourceChannels)
                     pcmEncoding = fmt.getIntegerOrDefault("pcm-encoding", PCM_ENCODING_16BIT)
-                    currentFrame = ShortArray(sourceChannels)
+                    if (newSr != sourceSampleRate || newCh != sourceChannels) {
+                        sourceSampleRate = newSr
+                        sourceChannels = newCh
+                        converter = Pcm16Converter(
+                            sourceSampleRate = sourceSampleRate,
+                            sourceChannels = sourceChannels,
+                            targetSampleRate = lastTargetSampleRate.takeIf { it > 0 } ?: 48_000,
+                            targetChannels = lastTargetChannels.takeIf { it > 0 } ?: 1
+                        )
+                    }
                 }
                 else -> {
-                    if (outIdx < 0) return false
+                    if (outIdx < 0) return null
                     val decoded = codec.getOutputBuffer(outIdx)
-                    val hasData = decoded != null && info.size > 0
-                    if (hasData) {
-                        decoded!!.position(info.offset)
+                    var pcmBytes: ByteArray? = null
+                    if (decoded != null && info.size > 0) {
+                        decoded.position(info.offset)
                         decoded.limit(info.offset + info.size)
-                        pendingSamples = decodePcm16(decoded)
-                        pendingFrameCount = pendingSamples.size / sourceChannels
+                        pcmBytes = decodeToPcm16Bytes(decoded)
                     }
                     if (info.flags and MediaCodec.BUFFER_FLAG_END_OF_STREAM != 0) {
                         outputDone = true
                     }
                     codec.releaseOutputBuffer(outIdx, false)
-                    if (pendingFrameCount > 0) return true
+                    if (pcmBytes != null && pcmBytes.isNotEmpty()) {
+                        return pcmBytes
+                    }
                 }
             }
         }
-        return false
+        return null
     }
 
     private fun feedInput() {
@@ -181,48 +183,28 @@ class FileAudioSource(
         }
     }
 
-    private fun decodePcm16(buffer: ByteBuffer): ShortArray {
+    private fun decodeToPcm16Bytes(buffer: ByteBuffer): ByteArray {
         val duplicate = buffer.slice().order(ByteOrder.LITTLE_ENDIAN)
         return when (pcmEncoding) {
             PCM_ENCODING_FLOAT -> {
-                val out = ShortArray(duplicate.remaining() / 4)
-                var i = 0
+                val sampleCount = duplicate.remaining() / 4
+                val out = ByteArray(sampleCount * 2)
+                var outIdx = 0
                 while (duplicate.remaining() >= 4) {
-                    val v = duplicate.float.coerceIn(-1f, 1f)
-                    out[i++] = (v * Short.MAX_VALUE).toInt().toShort()
+                    val v = duplicate.float
+                    val limited = Pcm16Converter.softLimit(v * 32767f)
+                    val s = limited.toInt().toShort()
+                    out[outIdx++] = (s.toInt() and 0xFF).toByte()
+                    out[outIdx++] = ((s.toInt() ushr 8) and 0xFF).toByte()
                 }
                 out
             }
             else -> {
-                val out = ShortArray(duplicate.remaining() / 2)
-                var i = 0
-                while (duplicate.remaining() >= 2) {
-                    out[i++] = duplicate.short
-                }
+                val out = ByteArray(duplicate.remaining())
+                duplicate.get(out)
                 out
             }
         }
-    }
-
-    private fun writeFrame(out: ByteBuffer, src: ShortArray, targetChannels: Int) {
-        for (channel in 0 until targetChannels) {
-            val sample = when {
-                sourceChannels == 1 -> src[0]
-                targetChannels == 1 -> (((src.getOrElse(0) { 0 }.toInt()) + src.getOrElse(1) { 0 }.toInt()) / 2).toShort()
-                channel < sourceChannels -> src[channel]
-                else -> 0
-            }
-            out.put((sample.toInt() and 0xFF).toByte())
-            out.put(((sample.toInt() ushr 8) and 0xFF).toByte())
-        }
-    }
-
-    private fun resetResampler(targetSampleRate: Int, targetChannels: Int) {
-        lastTargetSampleRate = targetSampleRate
-        lastTargetChannels = targetChannels
-        sourceCursor = 0.0
-        hasCurrentFrame = false
-        generatedTargetFrames = positionUs * targetSampleRate / 1_000_000L
     }
 
     override fun positionMs(): Long = positionUs / 1000
@@ -235,11 +217,9 @@ class FileAudioSource(
             inputDone = false
             outputDone = false
             positionUs = 0L
-            pendingSamples = ShortArray(0)
-            pendingFrameOffset = 0
-            pendingFrameCount = 0
-            sourceCursor = 0.0
-            hasCurrentFrame = false
+            converter?.reset()
+            convertedBuffer = ByteArray(0)
+            convertedOffset = 0
             generatedTargetFrames = 0L
         }.onFailure { GlassLog.b("FileAudio") { "reset failed: ${it.message}" } }
     }
@@ -252,11 +232,9 @@ class FileAudioSource(
             inputDone = false
             outputDone = false
             positionUs = safe * 1000
-            pendingSamples = ShortArray(0)
-            pendingFrameOffset = 0
-            pendingFrameCount = 0
-            sourceCursor = 0.0
-            hasCurrentFrame = false
+            converter?.reset()
+            convertedBuffer = ByteArray(0)
+            convertedOffset = 0
             generatedTargetFrames = positionUs * (lastTargetSampleRate.takeIf { it > 0 } ?: 48_000) / 1_000_000L
         }.onFailure { GlassLog.b("FileAudio") { "seekTo failed: ${it.message}" } }
     }
@@ -277,3 +255,4 @@ class FileAudioSource(
 
 private fun MediaFormat.getIntegerOrDefault(key: String, defaultValue: Int): Int =
     if (containsKey(key)) runCatching { getInteger(key) }.getOrDefault(defaultValue) else defaultValue
+

--- a/app/src/main/java/io/mo/glassmic/audio/Pcm16Converter.kt
+++ b/app/src/main/java/io/mo/glassmic/audio/Pcm16Converter.kt
@@ -1,13 +1,22 @@
 package io.mo.glassmic.audio
 
+import kotlin.math.PI
+import kotlin.math.cos
+import kotlin.math.sin
+
 /**
- * 流式 PCM16（小端、交错）重采样 + 声道混合。
+ * 高保真流式 PCM16（小端、交错）重采样 + 声道混合器。
  *
- * 把 [sourceSampleRate]/[sourceChannels] 的输入增量转换到
- * [targetSampleRate]/[targetChannels]。内部保留跨调用的样本游标与未消费样本，
- * 因此可以一小块一小块地喂数据。源/目标一致时零拷贝直接返回。
- *
- * 由 SharedPcmPublisher（每 consumer 一份）与 TtsAudioSource 共用。
+ * 特性：
+ * 1. 自动抗混叠低通滤波（Anti-Aliasing Windowed-Sinc FIR Filter）：
+ *    在下采样（如 48k -> 16k）时滤除高于目标奈奎斯特极限的高频成分，彻底杜绝微信等
+ *    语音 App 中的金属破音、高频嘶嘶杂音和齿音混叠。
+ * 2. 亚样本线性平滑插值（Sub-sample Linear Interpolation）：
+ *    消除非整数倍采样转换中的阶梯时域伪影。
+ * 3. 跨分块流式状态连续性（Streaming State Preservation）：
+ *    保留滤波器历史样本和时钟小数偏移，保证块间波形严格连续、零爆音。
+ * 4. 软限幅器（Soft Knee Limiter）：
+ *    防止滤波引起的峰值过冲导致的方波削波破音。
  */
 internal class Pcm16Converter(
     private val sourceSampleRate: Int,
@@ -15,81 +24,291 @@ internal class Pcm16Converter(
     private val targetSampleRate: Int,
     private val targetChannels: Int
 ) {
-    private var pending = ShortArray(0)
-    private var sourcePosition = 0.0
+    private val isPassThrough = sourceSampleRate == targetSampleRate && sourceChannels == targetChannels
 
+    // 重采样比例：每个目标样本对应多少个源样本
+    private val ratio = sourceSampleRate.toDouble() / targetSampleRate.toDouble()
+
+    // FIR 滤波器参数
+    private val filterTaps: Int
+    private val filterHalf: Int
+    private val firCoeffs: FloatArray
+    private val needsFilter: Boolean
+
+    // 历史样本环形/滑动缓冲（单通道浮点，用于滤波与插值）
+    // 每个源通道独立维护历史缓冲
+    private var sourceHistory: Array<FloatArray>
+    private var historyCount: Int = 0
+
+    // 源时间小数游标（相对于 history 中有效源样本的偏移）
+    private var sourceCursor: Double = 0.0
+
+    // 未消费完的待转换字节（用于处理输入字节不足一帧的情况）
+    private var pendingBytes = ByteArray(0)
+
+    init {
+        val safeSourceRate = sourceSampleRate.coerceAtLeast(8000)
+        val safeTargetRate = targetSampleRate.coerceAtLeast(8000)
+
+        // 当需要降采样或者源目标采样率不一致时设计抗混叠低通滤波器
+        if (safeTargetRate < safeSourceRate) {
+            needsFilter = true
+            // 截止频率设为目标奈奎斯特频率的 0.45 倍（例如 16kHz 时为 7.2kHz）
+            val cutoff = 0.45 * safeTargetRate
+            val normalizedCutoff = (cutoff / safeSourceRate).coerceIn(0.01, 0.49)
+            // 27 阶对称 FIR 滤波器，兼顾极高声音保真度与超低 CPU 消耗
+            filterTaps = 27
+            filterHalf = filterTaps / 2
+            firCoeffs = designLowPassFir(filterTaps, normalizedCutoff)
+        } else if (safeTargetRate > safeSourceRate) {
+            // 升采样时（如 44.1k -> 48k）进行抗镜像平滑滤波
+            needsFilter = true
+            val cutoff = 0.45 * safeSourceRate
+            val normalizedCutoff = (cutoff / safeSourceRate).coerceIn(0.01, 0.49)
+            filterTaps = 21
+            filterHalf = filterTaps / 2
+            firCoeffs = designLowPassFir(filterTaps, normalizedCutoff)
+        } else {
+            needsFilter = false
+            filterTaps = 1
+            filterHalf = 0
+            firCoeffs = floatArrayOf(1.0f)
+        }
+
+        sourceHistory = Array(sourceChannels.coerceAtLeast(1)) { FloatArray(0) }
+    }
+
+    /**
+     * 将输入的 PCM16 小端字节数据转换到目标规格。
+     */
     fun convert(bytes: ByteArray): ByteArray {
-        if (sourceSampleRate == targetSampleRate && sourceChannels == targetChannels) {
-            return bytes
+        if (bytes.isEmpty()) return ByteArray(0)
+        if (isPassThrough) return bytes
+
+        val totalBytes = if (pendingBytes.isNotEmpty()) {
+            val combined = ByteArray(pendingBytes.size + bytes.size)
+            System.arraycopy(pendingBytes, 0, combined, 0, pendingBytes.size)
+            System.arraycopy(bytes, 0, combined, pendingBytes.size, bytes.size)
+            pendingBytes = ByteArray(0)
+            combined
+        } else {
+            bytes
         }
 
-        append(bytes)
-        if (pending.isEmpty()) return ByteArray(0)
-
-        val step = sourceSampleRate.toDouble() / targetSampleRate.toDouble()
-        val frames = ArrayList<ShortArray>(pending.size / sourceChannels)
-        while (sourcePosition < frameCount()) {
-            val sourceFrame = sourcePosition.toInt()
-            frames += mixFrame(sourceFrame)
-            sourcePosition += step
+        val bytesPerSourceFrame = sourceChannels * 2
+        val availableFrames = totalBytes.size / bytesPerSourceFrame
+        if (availableFrames <= 0) {
+            pendingBytes = totalBytes
+            return ByteArray(0)
         }
 
-        trimConsumedSourceFrames()
-        if (frames.isEmpty()) return ByteArray(0)
+        val consumedBytes = availableFrames * bytesPerSourceFrame
+        val remainderBytes = totalBytes.size - consumedBytes
+        if (remainderBytes > 0) {
+            pendingBytes = ByteArray(remainderBytes)
+            System.arraycopy(totalBytes, consumedBytes, pendingBytes, 0, remainderBytes)
+        }
 
-        val out = ByteArray(frames.size * targetChannels * 2)
-        var offset = 0
-        frames.forEach { frame ->
-            frame.forEach { sample ->
-                out[offset++] = (sample.toInt() and 0xFF).toByte()
-                out[offset++] = ((sample.toInt() ushr 8) and 0xFF).toByte()
+        // 解码输入为每个声道的浮点数组
+        val newSourceSamples = Array(sourceChannels) { FloatArray(availableFrames) }
+        var byteOffset = 0
+        for (f in 0 until availableFrames) {
+            for (ch in 0 until sourceChannels) {
+                val lo = totalBytes[byteOffset].toInt() and 0xFF
+                val hi = totalBytes[byteOffset + 1].toInt()
+                val sampleShort = ((hi shl 8) or lo).toShort()
+                newSourceSamples[ch][f] = sampleShort.toFloat()
+                byteOffset += 2
             }
         }
-        return out
-    }
 
-    private fun append(bytes: ByteArray) {
-        val samplesToAdd = bytes.size / 2
-        if (samplesToAdd <= 0) return
-
-        val combined = ShortArray(pending.size + samplesToAdd)
-        pending.copyInto(combined)
-        var src = 0
-        var dst = pending.size
-        while (src + 1 < bytes.size) {
-            val lo = bytes[src].toInt() and 0xFF
-            val hi = bytes[src + 1].toInt()
-            combined[dst++] = ((hi shl 8) or lo).toShort()
-            src += 2
+        // 将新样本追加到历史缓冲中
+        val oldHistoryCount = historyCount
+        val totalSourceFrames = oldHistoryCount + availableFrames
+        val combinedHistory = Array(sourceChannels) { ch ->
+            val buf = FloatArray(totalSourceFrames)
+            if (oldHistoryCount > 0) {
+                System.arraycopy(sourceHistory[ch], 0, buf, 0, oldHistoryCount)
+            }
+            System.arraycopy(newSourceSamples[ch], 0, buf, oldHistoryCount, availableFrames)
+            buf
         }
-        pending = combined
-    }
 
-    private fun frameCount(): Int = pending.size / sourceChannels
+        // 估计输出帧数并预分配
+        val estimatedOutFrames = ((totalSourceFrames - filterTaps - sourceCursor) / ratio).toInt().coerceAtLeast(0) + 16
+        val outChannelsData = Array(targetChannels) { FloatArray(estimatedOutFrames) }
+        var outFrameCount = 0
 
-    private fun mixFrame(frameIndex: Int): ShortArray {
-        val base = frameIndex * sourceChannels
-        return ShortArray(targetChannels) { channel ->
-            when {
-                sourceChannels == 1 -> pending.getOrElse(base) { 0 }
-                targetChannels == 1 -> {
-                    val left = pending.getOrElse(base) { 0 }.toInt()
-                    val right = pending.getOrElse(base + 1) { 0 }.toInt()
-                    ((left + right) / 2).toShort()
+        // 只要游标加上滤波半窗仍在有效历史范围内，就可以持续产生目标帧
+        while (true) {
+            val centerIndex = sourceCursor.toInt()
+            // 判断是否已超出当前可用源样本的滤波右边界
+            if (centerIndex + filterHalf + 1 >= totalSourceFrames) {
+                break
+            }
+
+            // 确保输出数组容量充足
+            if (outFrameCount >= outChannelsData[0].size) {
+                val newCap = outChannelsData[0].size * 2 + 32
+                for (ch in 0 until targetChannels) {
+                    val expanded = FloatArray(newCap)
+                    System.arraycopy(outChannelsData[ch], 0, expanded, 0, outFrameCount)
+                    outChannelsData[ch] = expanded
                 }
-                channel < sourceChannels -> pending.getOrElse(base + channel) { 0 }
-                else -> 0
+            }
+
+            // 逐个源通道计算滤波与亚样本插值后的值
+            val filteredSource = FloatArray(sourceChannels)
+            val frac = (sourceCursor - centerIndex).toFloat()
+
+            for (ch in 0 until sourceChannels) {
+                val chHistory = combinedHistory[ch]
+                if (needsFilter) {
+                    // 对 centerIndex 和 centerIndex + 1 分别做 FIR 滤波，再按 frac 进行线性插值
+                    var sum0 = 0.0f
+                    var sum1 = 0.0f
+                    val base0 = centerIndex - filterHalf
+                    val base1 = base0 + 1
+
+                    for (k in 0 until filterTaps) {
+                        val coeff = firCoeffs[k]
+                        val idx0 = (base0 + k).coerceIn(0, totalSourceFrames - 1)
+                        val idx1 = (base1 + k).coerceIn(0, totalSourceFrames - 1)
+                        sum0 += chHistory[idx0] * coeff
+                        sum1 += chHistory[idx1] * coeff
+                    }
+                    filteredSource[ch] = sum0 + (sum1 - sum0) * frac
+                } else {
+                    // 无滤波时直接线性插值
+                    val s0 = chHistory[centerIndex.coerceIn(0, totalSourceFrames - 1)]
+                    val s1 = chHistory[(centerIndex + 1).coerceIn(0, totalSourceFrames - 1)]
+                    filteredSource[ch] = s0 + (s1 - s0) * frac
+                }
+            }
+
+            // 声道映射
+            for (dstCh in 0 until targetChannels) {
+                val sampleValue = when {
+                    sourceChannels == 1 -> filteredSource[0]
+                    targetChannels == 1 -> (filteredSource[0] + filteredSource[1]) * 0.5f
+                    dstCh < sourceChannels -> filteredSource[dstCh]
+                    else -> 0.0f
+                }
+                outChannelsData[dstCh][outFrameCount] = sampleValue
+            }
+
+            outFrameCount++
+            sourceCursor += ratio
+        }
+
+        // 保留尾部未消费完的源样本作为下一次的 history
+        val consumedSourceFrames = sourceCursor.toInt() - filterHalf
+        val retainStart = consumedSourceFrames.coerceAtLeast(0).coerceAtMost(totalSourceFrames)
+        val retainedCount = totalSourceFrames - retainStart
+
+        sourceHistory = Array(sourceChannels) { ch ->
+            val retained = FloatArray(retainedCount)
+            if (retainedCount > 0) {
+                System.arraycopy(combinedHistory[ch], retainStart, retained, 0, retainedCount)
+            }
+            retained
+        }
+        historyCount = retainedCount
+        sourceCursor -= retainStart
+
+        if (outFrameCount <= 0) return ByteArray(0)
+
+        // 软限幅 + 打包为 PCM16 小端字节数组
+        val outBytes = ByteArray(outFrameCount * targetChannels * 2)
+        var outByteIndex = 0
+        for (f in 0 until outFrameCount) {
+            for (ch in 0 until targetChannels) {
+                val raw = outChannelsData[ch][f]
+                val limited = softLimit(raw)
+                val s = limited.toInt().toShort()
+                outBytes[outByteIndex++] = (s.toInt() and 0xFF).toByte()
+                outBytes[outByteIndex++] = ((s.toInt() ushr 8) and 0xFF).toByte()
             }
         }
+
+        return outBytes
     }
 
-    private fun trimConsumedSourceFrames() {
-        val frames = frameCount()
-        val consumed = sourcePosition.toInt().coerceAtMost(frames)
-        if (consumed <= 0) return
+    /**
+     * 重置内部状态（用于 seek 或源切换）
+     */
+    fun reset() {
+        historyCount = 0
+        sourceCursor = 0.0
+        pendingBytes = ByteArray(0)
+        sourceHistory = Array(sourceChannels.coerceAtLeast(1)) { FloatArray(0) }
+    }
 
-        val consumedSamples = consumed * sourceChannels
-        pending = pending.copyOfRange(consumedSamples, pending.size)
-        sourcePosition -= consumed
+    companion object {
+        /**
+         * 设计对称 Windowed-Sinc 低通 FIR 滤波器（Blackman-Harris 窗）
+         * @param taps 抽头数（奇数）
+         * @param normalizedCutoff 归一化截止频率（0 < cutoff < 0.5）
+         */
+        fun designLowPassFir(taps: Int, normalizedCutoff: Double): FloatArray {
+            val coeffs = FloatArray(taps)
+            val m = taps - 1
+            val center = m / 2.0
+            var sum = 0.0
+
+            for (i in 0 until taps) {
+                val n = i - center
+                // Sinc 函数
+                val sinc = if (n == 0.0) {
+                    2.0 * PI * normalizedCutoff
+                } else {
+                    sin(2.0 * PI * normalizedCutoff * n) / n
+                }
+                // Blackman-Harris 窗，提供 >60dB 的旁瓣衰减，抗混叠能力极强
+                val a0 = 0.35875
+                val a1 = 0.48829
+                val a2 = 0.14128
+                val a3 = 0.01168
+                val w = a0 - a1 * cos(2.0 * PI * i / m) + a2 * cos(4.0 * PI * i / m) - a3 * cos(6.0 * PI * i / m)
+
+                val val_i = sinc * w
+                coeffs[i] = val_i.toFloat()
+                sum += val_i
+            }
+
+            // 归一化直流增益为 1.0 (0 dB)
+            if (sum > 1e-6) {
+                val invSum = (1.0 / sum).toFloat()
+                for (i in 0 until taps) {
+                    coeffs[i] *= invSum
+                }
+            }
+
+            return coeffs
+        }
+
+        /**
+         * 平滑软限幅器（Soft Knee Limiter）：
+         * 在 |x| <= 30000 范围保持 100% 线性；
+         * 在 |x| > 30000 范围使用双曲正切软过渡到 32767，消除峰值方波削波失真。
+         */
+        fun softLimit(sample: Float): Float {
+            val threshold = 30000.0f
+            val maxVal = 32767.0f
+            val absVal = if (sample < 0f) -sample else sample
+
+            if (absVal <= threshold) {
+                return sample
+            }
+
+            val over = absVal - threshold
+            val range = maxVal - threshold
+            // 快速软拐点近似：tanh(over / range)
+            val normalizedOver = over / range
+            val softOver = (normalizedOver / (1.0f + normalizedOver)) * range
+            val limited = threshold + softOver
+
+            return if (sample < 0f) -limited else limited
+        }
     }
 }

--- a/app/src/main/java/io/mo/glassmic/audio/SharedPcmPublisher.kt
+++ b/app/src/main/java/io/mo/glassmic/audio/SharedPcmPublisher.kt
@@ -78,6 +78,7 @@ class SharedPcmPublisher @Inject constructor(
         const val BYTES_PER_SAMPLE = 2
         const val MASTER_SAMPLE_RATE = 48_000
         const val MASTER_CHANNELS = 1
+        const val FRAME_CHUNK_BYTES = 1920 // 20ms @ 48kHz 单声道 PCM16，切片更细更平滑
         const val NOISE_SIM_AMPLITUDE = 6_000
         const val HIGH_GAIN_MULTIPLIER = 1.8f
         const val REVERB_DELAY_SAMPLES = 2_880   // 60ms @48k 单声道
@@ -153,7 +154,7 @@ class SharedPcmPublisher @Inject constructor(
         val id = buildConsumerId(consumerPackage)
         val fos = FileOutputStream(writeFd.fileDescriptor)
         val queue = Channel<ByteArray>(
-            capacity = 3,
+            capacity = 16,
             onBufferOverflow = BufferOverflow.DROP_OLDEST
         )
         val safeSampleRate = sampleRate.coerceAtLeast(8_000)
@@ -215,13 +216,16 @@ class SharedPcmPublisher @Inject constructor(
             writerStarted = true
         }
         scope.launch {
-            val frame = ByteBuffer.allocate(4096)
-            // 用时间戳维持实时节奏，避免每帧 delay 累计误差
-            var nextSendAt = System.currentTimeMillis()
+            runCatching {
+                android.os.Process.setThreadPriority(android.os.Process.THREAD_PRIORITY_URGENT_AUDIO)
+            }
+            val frame = ByteBuffer.allocate(FRAME_CHUNK_BYTES)
+            // 用纳秒高精度时钟维持实时节奏，避免每帧 delay 累计误差与时钟漂移
+            var nextSendAtNanos = System.nanoTime()
             while (isActive) {
                 if (consumers.isEmpty()) {
                     kotlinx.coroutines.delay(50)
-                    nextSendAt = System.currentTimeMillis()  // 没消费者时重置基准
+                    nextSendAtNanos = System.nanoTime()  // 没消费者时重置基准
                     continue
                 }
                 frame.clear()
@@ -247,22 +251,22 @@ class SharedPcmPublisher @Inject constructor(
                         // 才能让消费端以正常采样率播放时得到正确的变速节奏
                         val outBytes = broadcast(frame)
 
-                        val frameMs = (outBytes.toLong() * 1000L + bytesPerSec - 1) / bytesPerSec
-                        nextSendAt += frameMs
-                        val now = System.currentTimeMillis()
-                        val sleep = nextSendAt - now
-                        if (sleep > 0) {
-                            kotlinx.coroutines.delay(sleep)
-                        } else if (sleep < -200) {
+                        val frameNanos = (outBytes.toLong() * 1_000_000_000L + bytesPerSec - 1) / bytesPerSec
+                        nextSendAtNanos += frameNanos
+                        val nowNanos = System.nanoTime()
+                        val sleepNanos = nextSendAtNanos - nowNanos
+                        if (sleepNanos > 0) {
+                            kotlinx.coroutines.delay(sleepNanos / 1_000_000L)
+                        } else if (sleepNanos < -200_000_000L) {
                             // 落后超过 200ms（被 GC / 系统抢占），追平基准，避免突然爆发
-                            nextSendAt = now
+                            nextSendAtNanos = nowNanos
                         }
                     }
                     n == -1 -> {
                         handleEof()
-                        nextSendAt = System.currentTimeMillis()
+                        nextSendAtNanos = System.nanoTime()
                     }
-                    else -> kotlinx.coroutines.delay(5)
+                    else -> kotlinx.coroutines.delay(2)
                 }
             }
         }

--- a/app/src/main/java/io/mo/glassmic/audio/SharedPcmPublisher.kt
+++ b/app/src/main/java/io/mo/glassmic/audio/SharedPcmPublisher.kt
@@ -44,7 +44,8 @@ class SharedPcmPublisher @Inject constructor(
     @ApplicationContext private val context: Context,
     private val runtime: RuntimeStateHolder,
     private val configStore: ConfigStore,
-    private val watchdog: SafeModeWatchdog
+    private val watchdog: SafeModeWatchdog,
+    private val monitorPlayer: AudioMonitorPlayer
 ) {
 
     private data class Consumer(
@@ -114,6 +115,10 @@ class SharedPcmPublisher @Inject constructor(
                     speed = exp.unlocked && exp.speedEnabled && speedRaw != 1f,
                     speedFactor = speedRaw
                 )
+                val mon = cfg.audioMonitor
+                monitorPlayer.setEnabled(mon.enabled)
+                val monVol = if (mon.volume <= 0f) 1.0f else mon.volume.coerceIn(0f, 1f)
+                monitorPlayer.setVolume(monVol)
             }
         }
     }
@@ -130,7 +135,11 @@ class SharedPcmPublisher @Inject constructor(
     fun setPaused(value: Boolean) {
         if (paused == value) return
         paused = value
+        if (value) {
+            monitorPlayer.pauseAndFlush()
+        }
         runtime.setPaused(value)
+        runtime.setStreaming(if (value) false else consumers.isNotEmpty())
         GlassLog.b("Publisher") { "paused=$value" }
     }
 
@@ -194,6 +203,7 @@ class SharedPcmPublisher @Inject constructor(
         groupId: String? = null,
         audioId: String? = null
     ) {
+        monitorPlayer.pauseAndFlush()
         currentSource.release()
         currentSource = src
         if (updateRuntime) {
@@ -224,10 +234,13 @@ class SharedPcmPublisher @Inject constructor(
             var nextSendAtNanos = System.nanoTime()
             while (isActive) {
                 if (consumers.isEmpty()) {
+                    runtime.setStreaming(false)
+                    monitorPlayer.pauseAndFlush()
                     kotlinx.coroutines.delay(50)
                     nextSendAtNanos = System.nanoTime()  // 没消费者时重置基准
                     continue
                 }
+                runtime.setStreaming(!paused)
                 frame.clear()
                 val sr = MASTER_SAMPLE_RATE
                 val ch = MASTER_CHANNELS
@@ -263,10 +276,14 @@ class SharedPcmPublisher @Inject constructor(
                         }
                     }
                     n == -1 -> {
+                        monitorPlayer.pauseAndFlush()
                         handleEof()
                         nextSendAtNanos = System.nanoTime()
                     }
-                    else -> kotlinx.coroutines.delay(2)
+                    else -> {
+                        monitorPlayer.pauseAndFlush()
+                        kotlinx.coroutines.delay(2)
+                    }
                 }
             }
         }
@@ -290,10 +307,15 @@ class SharedPcmPublisher @Inject constructor(
     private fun broadcast(buf: ByteBuffer): Int {
         val data = ByteArray(buf.remaining())
         buf.get(data)
-        val sourceData = if (!paused && currentSource.type == SourceType.FILE) {
+        val sourceData = if (!paused && (currentSource.type == SourceType.FILE || currentSource.type == SourceType.TTS)) {
             applyEffects(data)
         } else {
             data
+        }
+        if (!paused && (currentSource.type == SourceType.FILE || currentSource.type == SourceType.TTS)) {
+            monitorPlayer.write(sourceData)
+        } else {
+            monitorPlayer.pauseAndFlush()
         }
         consumers.values.forEach { c ->
             val payload = c.converter.convert(sourceData)

--- a/app/src/main/java/io/mo/glassmic/audio/SharedPcmPublisher.kt
+++ b/app/src/main/java/io/mo/glassmic/audio/SharedPcmPublisher.kt
@@ -163,7 +163,7 @@ class SharedPcmPublisher @Inject constructor(
         val id = buildConsumerId(consumerPackage)
         val fos = FileOutputStream(writeFd.fileDescriptor)
         val queue = Channel<ByteArray>(
-            capacity = 16,
+            capacity = 32,
             onBufferOverflow = BufferOverflow.DROP_OLDEST
         )
         val safeSampleRate = sampleRate.coerceAtLeast(8_000)

--- a/app/src/main/java/io/mo/glassmic/data/audio/PlaybackController.kt
+++ b/app/src/main/java/io/mo/glassmic/data/audio/PlaybackController.kt
@@ -1,5 +1,9 @@
 package io.mo.glassmic.data.audio
 
+import android.media.AudioAttributes
+import android.media.AudioFormat
+import android.media.AudioManager
+import android.media.AudioTrack
 import io.mo.glassmic.audio.BufferedPcmSource
 import io.mo.glassmic.audio.FileAudioSource
 import io.mo.glassmic.audio.Pcm16Converter
@@ -17,11 +21,15 @@ import io.mo.glassmic.memory.MemoryPressure
 import io.mo.glassmic.memory.MemoryPressureBus
 import io.mo.glassmic.memory.MemoryReleasable
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
@@ -82,13 +90,96 @@ class PlaybackController @Inject constructor(
     /** 生成状态：供悬浮窗决定「播放」按钮是否可用。 */
     val ttsGen: StateFlow<TtsGen> = _ttsGen.asStateFlow()
 
+    private val _ttsPreviewing = MutableStateFlow(false)
+    /** 本地试听状态：供悬浮窗显示试听/停止按钮。 */
+    val ttsPreviewing: StateFlow<Boolean> = _ttsPreviewing.asStateFlow()
+    private var previewJob: Job? = null
+    private var previewTrack: AudioTrack? = null
+
     @Volatile private var generatedTtsPcm: ByteArray? = null
+
+    /**
+     * 在本机扬声器/耳机试听上次生成的语音（不占用虚拟麦克风推流管线）。
+     */
+    suspend fun togglePreviewTts() = withContext(Dispatchers.IO) {
+        if (_ttsPreviewing.value) {
+            stopPreviewTts()
+        } else {
+            startPreviewTts()
+        }
+    }
+
+    fun stopPreviewTts() {
+        previewJob?.cancel()
+        previewJob = null
+        previewTrack?.let {
+            runCatching { it.stop() }
+            runCatching { it.release() }
+        }
+        previewTrack = null
+        _ttsPreviewing.value = false
+    }
+
+    private fun startPreviewTts() {
+        val pcm = generatedTtsPcm ?: run {
+            GlassLog.b("Playback") { "TTS 试听失败：尚未生成语音" }
+            return
+        }
+        stopPreviewTts()
+        previewJob = CoroutineScope(Dispatchers.IO).launch {
+            _ttsPreviewing.value = true
+            try {
+                val minBuf = AudioTrack.getMinBufferSize(
+                    MASTER_SAMPLE_RATE,
+                    AudioFormat.CHANNEL_OUT_MONO,
+                    AudioFormat.ENCODING_PCM_16BIT
+                )
+                val track = AudioTrack(
+                    AudioAttributes.Builder()
+                        .setUsage(AudioAttributes.USAGE_MEDIA)
+                        .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
+                        .build(),
+                    AudioFormat.Builder()
+                        .setSampleRate(MASTER_SAMPLE_RATE)
+                        .setEncoding(AudioFormat.ENCODING_PCM_16BIT)
+                        .setChannelMask(AudioFormat.CHANNEL_OUT_MONO)
+                        .build(),
+                    maxOf(minBuf, MASTER_SAMPLE_RATE * 2),
+                    AudioTrack.MODE_STREAM,
+                    AudioManager.AUDIO_SESSION_ID_GENERATE
+                )
+                previewTrack = track
+                track.play()
+                var written = 0
+                val chunkSize = 4096
+                while (isActive && written < pcm.size) {
+                    val len = minOf(chunkSize, pcm.size - written)
+                    val ret = track.write(pcm, written, len)
+                    if (ret < 0) break
+                    written += ret
+                }
+                // 等待缓冲音频播放完毕：计算实际播放时长
+                val durationMs = pcm.size.toLong() * 1000 / (MASTER_SAMPLE_RATE * 2)
+                delay(durationMs + 300)
+            } catch (t: Throwable) {
+                GlassLog.b("Playback") { "TTS 试听异常: ${t.message}" }
+            } finally {
+                previewTrack?.let {
+                    runCatching { it.stop() }
+                    runCatching { it.release() }
+                }
+                previewTrack = null
+                _ttsPreviewing.value = false
+            }
+        }
+    }
 
     /**
      * 生成 [text] 的语音并缓存为主格式 PCM（不立即播放）。成功返回 true。
      * 之后调用 [playGeneratedTts] 才真正喂给目标 App，可重复播放。
      */
     suspend fun generateTts(text: String): Boolean = withContext(Dispatchers.IO) {
+        stopPreviewTts()
         val trimmed = text.trim()
         if (trimmed.isEmpty()) return@withContext false
         _ttsGen.value = TtsGen.GENERATING
@@ -126,6 +217,7 @@ class PlaybackController @Inject constructor(
      * （被取消则返回 false）。
      */
     suspend fun playGeneratedTts(): Boolean = withContext(Dispatchers.IO) {
+        stopPreviewTts()
         val pcm = generatedTtsPcm ?: return@withContext false
 
         val delayMs = configStore.current().tts.delayMs.toLong().coerceAtLeast(0L)

--- a/app/src/main/java/io/mo/glassmic/data/runtime/RuntimeStateHolder.kt
+++ b/app/src/main/java/io/mo/glassmic/data/runtime/RuntimeStateHolder.kt
@@ -57,6 +57,9 @@ class RuntimeStateHolder @Inject constructor() {
     fun setFloatingVisible(visible: Boolean) =
         _flow.update { it.copy(floatingWindowVisible = visible) }
 
+    fun setStreaming(streaming: Boolean) =
+        _flow.update { if (it.isStreaming == streaming) it else it.copy(isStreaming = streaming) }
+
     fun setError(msg: String?) = _flow.update { it.copy(lastError = msg) }
 
     fun reset() {

--- a/app/src/main/java/io/mo/glassmic/service/FloatingBubbleUi.kt
+++ b/app/src/main/java/io/mo/glassmic/service/FloatingBubbleUi.kt
@@ -111,6 +111,9 @@ fun FloatingBubbleRoot(
     mode: FloatMode,
     activeFile: Boolean,
     paused: Boolean,
+    isStreaming: Boolean = false,
+    audioMonitorEnabled: Boolean = false,
+    onToggleAudioMonitor: () -> Unit = {},
     positionMs: Long,
     durationMs: Long,
     currentName: String?,
@@ -129,7 +132,9 @@ fun FloatingBubbleRoot(
     ttsGenerating: Boolean,
     ttsReady: Boolean,
     ttsFailed: Boolean,
+    ttsPreviewing: Boolean = false,
     onGenerateTts: (String) -> Unit,
+    onTogglePreviewTts: () -> Unit = {},
     onPlayTts: () -> Unit,
     ttsProgressBarEnabled: Boolean,
     ttsActive: Boolean,
@@ -155,7 +160,8 @@ fun FloatingBubbleRoot(
             sizeDp = sizeDp,
             iconPath = iconPath,
             opacity = opacity,
-            active = activeFile && !paused,
+            active = (activeFile || ttsActive) && !paused,
+            isStreaming = isStreaming,
             positionMs = positionMs,
             durationMs = durationMs,
             onTap = onBallTap,
@@ -165,6 +171,9 @@ fun FloatingBubbleRoot(
 
         FloatMode.MINI_BAR -> MiniBar(
             paused = paused,
+            isStreaming = isStreaming,
+            audioMonitorEnabled = audioMonitorEnabled,
+            onToggleAudioMonitor = onToggleAudioMonitor,
             positionMs = positionMs,
             durationMs = durationMs,
             currentName = currentName,
@@ -205,8 +214,13 @@ fun FloatingBubbleRoot(
                         generating = ttsGenerating,
                         ready = ttsReady,
                         failed = ttsFailed,
+                        previewing = ttsPreviewing,
                         onGenerate = onGenerateTts,
+                        onPreview = onTogglePreviewTts,
                         onPlay = onPlayTts,
+                        isStreaming = isStreaming,
+                        audioMonitorEnabled = audioMonitorEnabled,
+                        onToggleAudioMonitor = onToggleAudioMonitor,
                         progressBarEnabled = ttsProgressBarEnabled,
                         ttsActive = ttsActive,
                         positionMs = positionMs,
@@ -345,6 +359,7 @@ private fun Ball(
     iconPath: String?,
     opacity: Float,
     active: Boolean,
+    isStreaming: Boolean,
     positionMs: Long,
     durationMs: Long,
     onTap: () -> Unit,
@@ -365,13 +380,15 @@ private fun Ball(
         animationSpec = if (reduceMotion) snap() else tween(120, easing = FastOutSlowInEasing),
         label = "ballScale"
     )
-    // 呼吸：播放中让描边/进度轨微微起伏，静止时保持恒定，避免无谓的持续重绘
+    // 呼吸：播放/推流中让描边/进度轨起伏，推流时起伏更活跃
     val breath = if (active && !reduceMotion) {
         val transition = rememberInfiniteTransition(label = "ballBreath")
+        val maxAlpha = if (isStreaming) 0.60f else 0.38f
+        val duration = if (isStreaming) 1200 else 2400
         transition.animateFloat(
             initialValue = 0.18f,
-            targetValue = 0.38f,
-            animationSpec = infiniteRepeatable(tween(2400, easing = FastOutSlowInEasing), RepeatMode.Reverse),
+            targetValue = maxAlpha,
+            animationSpec = infiniteRepeatable(tween(duration, easing = FastOutSlowInEasing), RepeatMode.Reverse),
             label = "ballBreathAlpha"
         ).value
     } else {
@@ -426,13 +443,13 @@ private fun Ball(
             )
             if (progress > 0f) {
                 drawArc(
-                    color = OverlayColors.Accent,
+                    color = if (isStreaming) OverlayColors.Accent else OverlayColors.Accent.copy(alpha = 0.8f),
                     startAngle = -90f,
                     sweepAngle = 360f * progress,
                     useCenter = false,
                     topLeft = topLeft,
                     size = arcSize,
-                    style = Stroke(width = stroke)
+                    style = Stroke(width = if (isStreaming) stroke * 1.3f else stroke)
                 )
             }
         }
@@ -450,12 +467,15 @@ private fun Ball(
                         Modifier
                             .background(
                                 Brush.radialGradient(
-                                    colors = listOf(Color.White.copy(alpha = 0.20f), Color.Transparent),
+                                    colors = listOf(
+                                        if (isStreaming) OverlayColors.Accent.copy(alpha = 0.25f) else Color.White.copy(alpha = 0.20f),
+                                        Color.Transparent
+                                    ),
                                     center = Offset(innerPx * 0.32f, innerPx * 0.22f),
                                     radius = innerPx * 0.9f
                                 )
                             )
-                            .border(BorderStroke(0.8.dp, Color.White.copy(alpha = breath)), CircleShape)
+                            .border(BorderStroke(0.8.dp, if (isStreaming) OverlayColors.Accent.copy(alpha = breath) else Color.White.copy(alpha = breath)), CircleShape)
                     } else {
                         Modifier
                     }
@@ -474,15 +494,16 @@ private fun Ball(
             }
         }
 
-        // 没有时长可展示时（未播放/流式音源），退回原来的状态指示点
-        if (durationMs <= 0) {
+        // 状态指示点：当正在推流时显示高亮绿点（或者没有时长时显示状态点）
+        if (isStreaming || durationMs <= 0) {
             Box(
                 modifier = Modifier
                     .align(Alignment.BottomEnd)
                     .padding(2.dp)
-                    .size(sizeDp.value.times(0.16f).dp.coerceAtLeast(6.dp))
+                    .size(sizeDp.value.times(0.18f).dp.coerceAtLeast(7.dp))
                     .clip(CircleShape)
-                    .background(if (active) OverlayColors.Accent else OverlayColors.Idle)
+                    .background(if (isStreaming) OverlayColors.Accent else if (active) OverlayColors.Accent.copy(alpha = 0.6f) else OverlayColors.Idle)
+                    .border(BorderStroke(1.dp, Color.Black.copy(alpha = 0.4f)), CircleShape)
             )
         }
     }
@@ -492,6 +513,9 @@ private fun Ball(
 @Composable
 private fun MiniBar(
     paused: Boolean,
+    isStreaming: Boolean,
+    audioMonitorEnabled: Boolean,
+    onToggleAudioMonitor: () -> Unit,
     positionMs: Long,
     durationMs: Long,
     currentName: String?,
@@ -509,19 +533,51 @@ private fun MiniBar(
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 Text("⠿", color = OverlayColors.OnDarkFaint, fontSize = 14.sp)
-                Spacer(Modifier.width(8.dp))
+                Spacer(Modifier.width(6.dp))
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = currentName ?: "GlassMic",
+                        color = OverlayColors.OnDark,
+                        fontSize = 13.sp,
+                        fontWeight = FontWeight.Medium,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Box(
+                            modifier = Modifier
+                                .size(6.dp)
+                                .clip(CircleShape)
+                                .background(if (isStreaming) OverlayColors.Accent else OverlayColors.Idle)
+                        )
+                        Spacer(Modifier.width(4.dp))
+                        Text(
+                            text = if (isStreaming) stringResource(R.string.float_streaming_live)
+                                   else stringResource(R.string.float_streaming_idle),
+                            color = if (isStreaming) OverlayColors.Accent else OverlayColors.OnDarkDim,
+                            fontSize = 10.sp
+                        )
+                    }
+                }
+                Spacer(Modifier.width(4.dp))
+                // 耳返监听快切
                 Text(
-                    text = currentName ?: "GlassMic",
-                    color = OverlayColors.OnDark,
-                    fontSize = 14.sp,
-                    fontWeight = FontWeight.Medium,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                    modifier = Modifier.weight(1f)
+                    text = "🎧",
+                    fontSize = 13.sp,
+                    modifier = Modifier
+                        .clip(CircleShape)
+                        .background(if (audioMonitorEnabled) OverlayColors.Accent.copy(alpha = 0.28f) else OverlayColors.FillStrong)
+                        .border(
+                            BorderStroke(0.8.dp, if (audioMonitorEnabled) OverlayColors.Accent else Color.Transparent),
+                            CircleShape
+                        )
+                        .clickable(onClick = onToggleAudioMonitor)
+                        .padding(horizontal = 7.dp, vertical = 5.dp)
                 )
+                Spacer(Modifier.width(4.dp))
                 // 换音源
                 IconChip(Icons.Filled.Refresh, stringResource(R.string.float_change_source), onOpenMenu)
-                Spacer(Modifier.width(6.dp))
+                Spacer(Modifier.width(4.dp))
                 // 播放/暂停
                 Text(
                     text = if (paused) "▶" else "⏸",
@@ -531,7 +587,7 @@ private fun MiniBar(
                         .clip(CircleShape)
                         .background(OverlayColors.FillStrong)
                         .clickable(onClick = onTogglePause)
-                        .padding(horizontal = 10.dp, vertical = 4.dp)
+                        .padding(horizontal = 9.dp, vertical = 4.dp)
                 )
             }
             Slider(
@@ -704,8 +760,13 @@ private fun TtsTab(
     generating: Boolean,
     ready: Boolean,
     failed: Boolean,
+    previewing: Boolean,
     onGenerate: (String) -> Unit,
+    onPreview: () -> Unit,
     onPlay: () -> Unit,
+    isStreaming: Boolean,
+    audioMonitorEnabled: Boolean,
+    onToggleAudioMonitor: () -> Unit,
     progressBarEnabled: Boolean,
     ttsActive: Boolean,
     positionMs: Long,
@@ -750,9 +811,50 @@ private fun TtsTab(
         )
     }
 
+    // 状态行：推流指示 + 耳返开关
     Row(
-        modifier = Modifier.fillMaxWidth().padding(top = 10.dp),
-        horizontalArrangement = Arrangement.spacedBy(10.dp),
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = 8.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Box(
+            modifier = Modifier
+                .size(6.dp)
+                .clip(CircleShape)
+                .background(if (isStreaming) OverlayColors.Accent else OverlayColors.Idle)
+        )
+        Spacer(Modifier.width(4.dp))
+        Text(
+            text = if (isStreaming) stringResource(R.string.float_streaming_live)
+                   else stringResource(R.string.float_streaming_idle),
+            color = if (isStreaming) OverlayColors.Accent else OverlayColors.OnDarkDim,
+            fontSize = 11.sp,
+            modifier = Modifier.weight(1f)
+        )
+        // 耳返开关
+        Row(
+            modifier = Modifier
+                .clip(RoundedCornerShape(OverlayShapes.Chip))
+                .background(if (audioMonitorEnabled) OverlayColors.Accent.copy(alpha = 0.25f) else OverlayColors.FillStrong)
+                .clickable(onClick = onToggleAudioMonitor)
+                .padding(horizontal = 8.dp, vertical = 3.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text("🎧", fontSize = 11.sp)
+            Spacer(Modifier.width(4.dp))
+            Text(
+                stringResource(R.string.float_audio_monitor),
+                color = if (audioMonitorEnabled) OverlayColors.Accent else OverlayColors.OnDarkDim,
+                fontSize = 11.sp
+            )
+        }
+    }
+
+    // 操作按钮行：生成 / 本地试听 / 注入播放
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(top = 8.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
         val canGenerate = !generating && text.isNotBlank()
@@ -764,6 +866,13 @@ private fun TtsTab(
             },
             style = if (canGenerate) PillStyle.Secondary else PillStyle.Disabled,
             onClick = { onGenerate(text.trim()) },
+            modifier = Modifier.weight(1f)
+        )
+        // 本地试听按钮
+        PillButton(
+            label = if (previewing) "⏹ 停止" else "🔊 试听",
+            style = if (ready) PillStyle.Secondary else PillStyle.Disabled,
+            onClick = onPreview,
             modifier = Modifier.weight(1f)
         )
         // 延时倒计时中：按钮变成「⏱ 1.5s 取消」，再点一次即取消本次播放
@@ -794,9 +903,9 @@ private fun TtsTab(
         )
     }
 
-    // 进度条：设置里开启后，生成/播放后可拖动控制播放进度
-    if (progressBarEnabled && (ready || ttsActive)) {
-        val hasDuration = ttsActive && durationMs > 0
+    // 进度条：生成就绪或正在播放时显示
+    if (ready || ttsActive) {
+        val hasDuration = durationMs > 0
         Slider(
             value = if (hasDuration) (positionMs.toFloat() / durationMs).coerceIn(0f, 1f) else 0f,
             onValueChange = onSeek,

--- a/app/src/main/java/io/mo/glassmic/service/FloatingWindowService.kt
+++ b/app/src/main/java/io/mo/glassmic/service/FloatingWindowService.kt
@@ -14,11 +14,13 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.LifecycleService
 import androidx.lifecycle.lifecycleScope
 import dagger.hilt.android.AndroidEntryPoint
+import io.mo.glassmic.R
 import io.mo.glassmic.core.Constants
 import io.mo.glassmic.core.model.SourceType
 import io.mo.glassmic.data.audio.FloatingIconStore
@@ -217,11 +219,13 @@ class FloatingWindowService : LifecycleService() {
                 val allClips by audioDao.observeAllClips().collectAsState(initial = emptyList())
                 val mode by modeFlow.collectAsState()
                 val ttsGen by playback.ttsGen.collectAsState()
+                val ttsPreviewing by playback.ttsPreviewing.collectAsState()
                 val ttsDelayRemainingMs by playback.ttsDelayRemainingMs.collectAsState()
 
-                val activeFile = rt.currentSourceType == SourceType.FILE && rt.enabled && !rt.safeMode
+                val activeFile = (rt.currentSourceType == SourceType.FILE || rt.currentSourceType == SourceType.TTS) && rt.enabled && !rt.safeMode
                 val currentId = cfg.currentAudioId
-                val currentName = allClips.firstOrNull { it.id == currentId }?.displayName
+                val currentName = if (rt.currentSourceType == SourceType.TTS) stringResource(R.string.source_tts)
+                                  else allClips.firstOrNull { it.id == currentId }?.displayName
 
                 // 悬浮窗不走 GlassMicTheme，这两个外观开关得在这里手动注入
                 CompositionLocalProvider(
@@ -232,6 +236,9 @@ class FloatingWindowService : LifecycleService() {
                     mode = mode,
                     activeFile = activeFile,
                     paused = rt.paused,
+                    isStreaming = rt.isStreaming,
+                    audioMonitorEnabled = cfg.audioMonitor.enabled,
+                    onToggleAudioMonitor = ::toggleAudioMonitor,
                     positionMs = rt.positionMs,
                     durationMs = rt.durationMs,
                     currentName = currentName,
@@ -255,7 +262,9 @@ class FloatingWindowService : LifecycleService() {
                     ttsGenerating = ttsGen == PlaybackController.TtsGen.GENERATING,
                     ttsReady = ttsGen == PlaybackController.TtsGen.READY,
                     ttsFailed = ttsGen == PlaybackController.TtsGen.FAILED,
+                    ttsPreviewing = ttsPreviewing,
                     onGenerateTts = { text -> onGenerateTts(text) },
+                    onTogglePreviewTts = { onTogglePreviewTts() },
                     onPlayTts = { onPlayTts() },
                     ttsProgressBarEnabled = cfg.tts.progressBarEnabled,
                     ttsActive = rt.currentSourceType == SourceType.TTS,
@@ -280,6 +289,21 @@ class FloatingWindowService : LifecycleService() {
     // ============ 手势 / 交互回调 ============
     private fun onBallTap(activeFile: Boolean) {
         setMode(if (activeFile) FloatMode.MINI_BAR else FloatMode.MENU)
+    }
+
+    private fun toggleAudioMonitor() {
+        lifecycleScope.launch {
+            configStore.update {
+                val cur = it.audioMonitor
+                it.setAudioMonitor(cur.toBuilder().setEnabled(!cur.enabled).build())
+            }
+        }
+    }
+
+    private fun onTogglePreviewTts() {
+        lifecycleScope.launch {
+            playback.togglePreviewTts()
+        }
     }
 
     private fun onSelectClip(clipId: String) {

--- a/app/src/main/java/io/mo/glassmic/service/GlassForegroundService.kt
+++ b/app/src/main/java/io/mo/glassmic/service/GlassForegroundService.kt
@@ -44,6 +44,8 @@ class GlassForegroundService : LifecycleService() {
     @Inject lateinit var playback: PlaybackController
     @Inject lateinit var fairMemory: FairMemoryController
 
+    private var wakeLock: android.os.PowerManager.WakeLock? = null
+
     override fun onCreate() {
         super.onCreate()
         ensureChannel()
@@ -52,6 +54,14 @@ class GlassForegroundService : LifecycleService() {
         ProviderGate.enable(this)
         // 创建运行哨兵——onDestroy 时删除
         runCatching { File(filesDir, Constants.RUNNING_SENTINEL).createNewFile() }
+        // 申请 Partial WakeLock，防止前台大型 3D 游戏高负载运行时系统激进冻结音频后台推流
+        runCatching {
+            val pm = getSystemService(Context.POWER_SERVICE) as? android.os.PowerManager
+            wakeLock = pm?.newWakeLock(android.os.PowerManager.PARTIAL_WAKE_LOCK, "glassmic:audiopush")?.apply {
+                setReferenceCounted(false)
+                acquire(10 * 60 * 60 * 1000L) // 最多持有 10 小时兜底
+            }
+        }
         startForegroundCompat()
         runtime.setEnabled(true)
         // 常驻期间才低频采样内存——服务不跑时本进程没有音频缓冲，也就没什么可看的
@@ -79,6 +89,12 @@ class GlassForegroundService : LifecycleService() {
     override fun onDestroy() {
         runtime.setEnabled(false)
         fairMemory.stopSampling()
+        runCatching {
+            if (wakeLock?.isHeld == true) {
+                wakeLock?.release()
+            }
+            wakeLock = null
+        }
         // 禁用跨进程 Provider——切断 AMS 强制拉起链路，服务停止后不再被无故复活。
         ProviderGate.disable(this)
         // 清理运行哨兵——表示本次正常退出

--- a/app/src/main/java/io/mo/glassmic/ui/home/HomeScreen.kt
+++ b/app/src/main/java/io/mo/glassmic/ui/home/HomeScreen.kt
@@ -228,9 +228,9 @@ private fun StatusHeroCard(
                 )
                 Text(
                     "${formatMs(state.positionMs)} / ${formatMs(state.durationMs)}" +
-                        if (state.paused) "  ·  已暂停" else "",
+                        if (state.paused) "  ·  已暂停" else if (state.isStreaming) "  ·  ● 推流录制中" else "",
                     style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f)
+                    color = if (state.isStreaming) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f)
                 )
             }
         }

--- a/app/src/main/java/io/mo/glassmic/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/io/mo/glassmic/ui/home/HomeViewModel.kt
@@ -37,6 +37,7 @@ data class HomeUiState(
     val policyLabel: String = "循环",
     val scopeLabel: String = "全局",
     val floatingWindowVisible: Boolean = false,
+    val isStreaming: Boolean = false,
     val positionMs: Long = 0L,
     val durationMs: Long = 0L,
     val progress: Float = 0f,
@@ -80,7 +81,7 @@ class HomeViewModel @Inject constructor(
         val group = groups.firstOrNull { it.id == rt.currentGroupId }
         HomeUiState(
             running = rt.enabled && !rt.safeMode && bootGate.userEnabledAfterBoot(),
-            hasFileSource = rt.currentSourceType == SourceType.FILE && clip != null,
+            hasFileSource = (rt.currentSourceType == SourceType.FILE && clip != null) || (rt.currentSourceType == SourceType.TTS && rt.durationMs > 0),
             paused = rt.paused,
             sourceName = when (rt.currentSourceType) {
                 SourceType.FILE -> clip?.displayName ?: rt.currentAudioId ?: "—"
@@ -102,6 +103,7 @@ class HomeViewModel @Inject constructor(
                 else -> AppLocale.string(context, R.string.scope_mode_global)
             },
             floatingWindowVisible = rt.floatingWindowVisible,
+            isStreaming = rt.isStreaming,
             positionMs = rt.positionMs,
             durationMs = rt.durationMs,
             progress = if (rt.durationMs > 0) rt.positionMs.toFloat() / rt.durationMs else 0f,

--- a/app/src/main/java/io/mo/glassmic/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/io/mo/glassmic/ui/settings/SettingsScreen.kt
@@ -213,6 +213,25 @@ fun SettingsScreen(
                 PlaybackPolicyPicker(cfg.playbackPolicy, vm::setPolicy)
             } }
 
+            item { Section(stringResource(R.string.settings_section_audio_monitor)) {
+                SwitchRow(
+                    label = stringResource(R.string.settings_audio_monitor_enabled),
+                    hint = stringResource(R.string.settings_audio_monitor_enabled_hint),
+                    checked = cfg.audioMonitor.enabled,
+                    onChange = vm::setAudioMonitorEnabled
+                )
+                if (cfg.audioMonitor.enabled) {
+                    val monVol = cfg.audioMonitor.volume.takeIf { it > 0f } ?: 1.0f
+                    LabeledSlider(
+                        label = stringResource(R.string.settings_audio_monitor_volume),
+                        value = monVol,
+                        valueRange = 0f..1f,
+                        display = "%.0f%%".format(monVol * 100),
+                        onChange = vm::setAudioMonitorVolume
+                    )
+                }
+            } }
+
             item { Section(stringResource(R.string.settings_section_compat)) {
                 SwitchRow(
                     label = stringResource(R.string.settings_visibility_compat),

--- a/app/src/main/java/io/mo/glassmic/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/io/mo/glassmic/ui/settings/SettingsViewModel.kt
@@ -188,8 +188,23 @@ class SettingsViewModel @Inject constructor(
      * 音量键双击快捷操作。开关只写配置——实际布防由悬浮窗服务在运行期间同步给 Xposed 侧，
      * 悬浮窗没开时这里打开也不会拦任何按键。
      */
-    fun setVolumeKeysEnabled(v: Boolean) = viewModelScope.launch {
-        configStore.update { it.setShortcuts(it.shortcuts.toBuilder().setVolumeKeysEnabled(v)) }
+    fun setVolumeKeysEnabled(enabled: Boolean) = viewModelScope.launch {
+        configStore.update { it.setShortcuts(it.shortcuts.toBuilder().setVolumeKeysEnabled(enabled)) }
+    }
+
+    // ============ 实时耳返 / 音频监听 ============
+    fun setAudioMonitorEnabled(enabled: Boolean) = viewModelScope.launch {
+        configStore.update {
+            val cur = it.audioMonitor
+            it.setAudioMonitor(cur.toBuilder().setEnabled(enabled))
+        }
+    }
+
+    fun setAudioMonitorVolume(volume: Float) = viewModelScope.launch {
+        configStore.update {
+            val cur = it.audioMonitor
+            it.setAudioMonitor(cur.toBuilder().setVolume(volume.coerceIn(0f, 1f)))
+        }
     }
 
     // ============ 默认播放策略 ============

--- a/app/src/main/proto/app_config.proto
+++ b/app/src/main/proto/app_config.proto
@@ -37,6 +37,15 @@ message AppConfig {
 
   // 物理按键快捷操作
   Shortcuts shortcuts = 17;
+
+  // 实时耳返 / 音频监听配置
+  AudioMonitor audio_monitor = 18;
+}
+
+// 实时耳返 / 本地监听播放：在虚拟麦克风推流时，同步通过扬声器/耳机输出声音
+message AudioMonitor {
+  bool enabled = 1;      // 是否开启实时监听/耳返
+  float volume = 2;      // 监听音量 0.0 - 1.0，0 视为 1.0
 }
 
 // 快捷操作：不碰屏幕就能控制虚拟麦克风的播放

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -292,5 +292,14 @@
     <string name="float_tts_delay_unit">sec</string>
     <string name="float_tts_delay_range">Enter a value between 0 and %1$d seconds</string>
     <string name="float_tts_delay_countdown">%1$ss · Cancel</string>
+    <string name="float_streaming_live">Streaming Live</string>
+    <string name="float_streaming_idle">Idle</string>
+    <string name="float_audio_monitor">Audio Monitor</string>
+
+    <!-- Settings → Live Audio Monitor -->
+    <string name="settings_section_audio_monitor">Live Audio Monitor</string>
+    <string name="settings_audio_monitor_enabled">Enable Live Audio Monitor</string>
+    <string name="settings_audio_monitor_enabled_hint">Simultaneously plays replaced audio through headphones/speakers while virtual mic is streaming</string>
+    <string name="settings_audio_monitor_volume">Monitor Volume</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -292,5 +292,14 @@
     <string name="float_tts_delay_unit">秒</string>
     <string name="float_tts_delay_range">请输入 0 到 %1$d 之间的秒数</string>
     <string name="float_tts_delay_countdown">%1$ss 取消</string>
+    <string name="float_streaming_live">录制推流中</string>
+    <string name="float_streaming_idle">待命中</string>
+    <string name="float_audio_monitor">耳返监听</string>
+
+    <!-- 设置页 → 实时耳返 / 音频监听 -->
+    <string name="settings_section_audio_monitor">实时耳返 / 监听</string>
+    <string name="settings_audio_monitor_enabled">开启实时耳返</string>
+    <string name="settings_audio_monitor_enabled_hint">在虚拟麦克风推流时，同步通过耳机/扬声器播放当前替换的音源内容</string>
+    <string name="settings_audio_monitor_volume">耳返监听音量</string>
 
 </resources>

--- a/core/src/main/java/io/mo/glassmic/core/model/RuntimeState.kt
+++ b/core/src/main/java/io/mo/glassmic/core/model/RuntimeState.kt
@@ -15,6 +15,7 @@ data class RuntimeState(
     val paused: Boolean = false,
     val playbackPolicy: PlaybackPolicy = PlaybackPolicy.LOOP,
     val floatingWindowVisible: Boolean = false,
+    val isStreaming: Boolean = false,
     val lastError: String? = null
 )
 

--- a/docs/ROBLOX_AUDIO_OPTIMIZATION.md
+++ b/docs/ROBLOX_AUDIO_OPTIMIZATION.md
@@ -1,0 +1,117 @@
+# Roblox 及重载在线游戏虚拟麦克风音频卡顿与中断问题 —— 深度代码优化规划方案
+
+## 1. 现状与根因技术定位 (Root Cause Analysis)
+
+通过对音频生成端 ([`SharedPcmPublisher`](file:///E:/Users/limo2/Desktop/project/Github/io.mo.glassmic/app/src/main/java/io/mo/glassmic/audio/SharedPcmPublisher.kt))、跨进程 IPC 管道 ([`PcmStreamProvider`](file:///E:/Users/limo2/Desktop/project/Github/io.mo.glassmic/app/src/main/java/io/mo/glassmic/provider/PcmStreamProvider.kt)) 以及目标进程原生注入端 ([`glass_aaudio.cpp`](file:///E:/Users/limo2/Desktop/project/Github/io.mo.glassmic/xposed/src/main/cpp/glass_aaudio.cpp), [`glass_opensl.cpp`](file:///E:/Users/limo2/Desktop/project/Github/io.mo.glassmic/xposed/src/main/cpp/glass_opensl.cpp), [`glass_audiorecord.cpp`](file:///E:/Users/limo2/Desktop/project/Github/io.mo.glassmic/xposed/src/main/cpp/glass_audiorecord.cpp)) 的源码排查，导致在《Roblox》等重载在线/直播游戏中音频断断续续和中断的技术根因如下：
+
+### 关键瓶颈点：
+1. **实时音频回调线程中执行阻塞式 IPC I/O**：
+   - `glass_aaudio.cpp` 和 `glass_opensl.cpp` 在游戏的 Real-Time 音频线程回调 (`my_AAudioStream_read` / `my_data_callback` / `my_bq_callback`) 中直接调用 `::read(fd, ...)`。
+   - 当游戏高负载导致 GlassMic 主进程产生几毫秒的调度延迟时，管道立即干涸，硬实时线程阻塞超时，触发音频欠载（Underrun / XRun）。
+2. **欠载处理机制粗糙导致声音畸变与回退**：
+   - 当 `read_full` 读取的字节少于目标帧需求时，`convert_and_write` 使用 `map_src_frame` 将不完整数据线性拉伸覆盖整帧，导致音频音调和语速发生抖动变调；
+   - 当读取返回 `<= 0` 时，直接返回 `FillResult::PASS` 回退到真实麦克风，造成虚拟声音断开、真麦杂音漏入。
+3. **音频广播线程优先级不足与 4096 字节大块突发推流**：
+   - `SharedPcmPublisher` 运行在默认优先级的 `Dispatchers.IO` 协程上，缺乏 `THREAD_PRIORITY_URGENT_AUDIO` 调度保障。
+   - 每次推流 4096 字节（~42.6ms），呈突发式（Burst）写入，而游戏端是以 5~10ms 小块消费，缓冲余量极脆弱。
+4. **游戏端原生采样率/声道固定盲写 (48kHz/Mono) 与粗糙重采样**：
+   - `NativeAAudioHook` 向 Provider 索取管道时固定请求 `sr=48000&ch=1`，若游戏内实际使用 16kHz/24kHz/44.1kHz 或立体声，C++ 层的最近邻/线性降采样缺乏抗混叠滤波，声音发干发刺，易触发游戏 VoIP 引擎的降噪切除。
+
+---
+
+## 2. 改造目标 (Goals)
+
+1. **零阻塞硬实时回调**：Native 音频回调从无锁环形缓冲区（Lock-Free RingBuffer）零等待读取，杜绝任何 IPC 阻塞导致的 XRun。
+2. **抗抖动自适应 Jitter Buffer**：在目标进程 Native 端维护 100ms~200ms 的平滑缓冲区，彻底吸收主进程由于 GC 或 CPU 调度引起的毫秒级抖动。
+3. **丢包/欠载平滑补偿 (PLC - Packet Loss Concealment)**：管道缺数据时，优雅过渡到舒适噪声或淡出，绝不发生音频拉伸变调或突然泄露真实麦克风。
+4. **主进程音频推流高优先级化**：推流线程提升为 `THREAD_PRIORITY_URGENT_AUDIO`，配合微小切片匀速写入与 partial wakelock 保活。
+5. **动态格式协商与高质量重采样**：支持目标进程 Native 端根据实际 Stream 参数按需开启格式协商。
+
+---
+
+## 3. 详细分阶段改造规划 (Phased Implementation Plan)
+
+### 阶段一：目标进程 Native 端重构 —— 引入后台读取线程与无锁环形缓冲 (Lock-Free RingBuffer)
+
+> **目标**：将硬实时 Audio Callback 与 Linux Pipe IPC 完全解耦。
+
+#### 1.1 实现 C++ 无锁 SPSC (Single Producer Single Consumer) 环形缓冲区
+* **新增文件**：`xposed/src/main/cpp/glass_ring_buffer.h`
+* **设计方案**：
+  - 基于 C++11 `std::atomic<size_t>` 实现无锁环形队列，容量预设为 192KB（约 1 秒 48kHz 16-bit PCM 数据）。
+  - 生产者：独立的 Native 管道拉取线程 (`PcmReaderWorker`)。
+  - 消费者：游戏的 Real-Time Audio Callback。
+  - 保证读取操作为 $O(1)$ 且零内存分配、零系统调用阻塞。
+
+#### 1.2 重构 `glass_aaudio.cpp` 与 `glass_opensl.cpp` 的消费逻辑
+* **修改逻辑**：
+  - 当 `set_pcm_fd` 传入新 fd 时，启动或重置 `PcmReaderWorker` 线程，持续在后台以 `read_full` 将数据从 Pipe 搬运至 RingBuffer 中。
+  - `fill_pcm_impl` 不再直接调用 `read(fd, ...)`，而是从 RingBuffer 中批量弹出所需的 PCM 帧。
+  - **欠载平滑处理**：
+    - 若 RingBuffer 中数据充足 $\ge$ 请求量：正常转换写入并返回 `FillResult::FILLED`；
+    - 若 RingBuffer 发生短暂欠载（数据不足）：优先将已有数据写出，不足部分**填充舒适噪声（Comfort Noise）或平滑淡出（Fade Out）**，绝不调用 `map_src_frame` 进行时间拉伸，且不返回 `PASS`（防止漏真麦）。
+
+---
+
+### 阶段二：主进程音频广播管线优化 —— 提高线程优先级与切片匀速推流
+
+> **目标**：提高 GlassMic 主进程推流的时钟精度与系统调度抗压能力。
+
+#### 2.1 引入专有音频 HandlerThread 与 Native 音频线程优先级
+* **修改文件**：[`SharedPcmPublisher.kt`](file:///E:/Users/limo2/Desktop/project/Github/io.mo.glassmic/app/src/main/java/io/mo/glassmic/audio/SharedPcmPublisher.kt)
+* **设计方案**：
+  - 将推流循环由默认的 `Dispatchers.IO` 协程迁移到独立的 `HandlerThread("GlassAudioPublisher")` 或专用线程。
+  - 启动时调用 `android.os.Process.setThreadPriority(Process.THREAD_PRIORITY_URGENT_AUDIO)`。
+  - 将推流分片从 4096 字节（~42.6ms）减小到 960 字节（10ms @ 48kHz mono）或 1920 字节（20ms），缩短推流周期的突发性，实现更加平滑匀速的水流式推流。
+
+#### 2.2 广播协程与消费者管道写入优化
+* **设计方案**：
+  - 将消费者管道写入协程的 Channel 队列由 `capacity = 3` 提升至 `capacity = 16`，防止在偶发 I/O 阻塞时丢弃数据。
+  - 采用基于纳秒高精度时钟 (`System.nanoTime()`) 的时间轴对齐算法，消除协程 `delay()` 毫秒级的累计漂移误差。
+
+---
+
+### 阶段三：服务保活与电源管理增强
+
+> **目标**：防止 Android 系统和各 OEM 游戏助手在游戏前台高负载时挂起 GlassMic。
+
+#### 3.1 增加播放中的 CPU Partial WakeLock 与低延迟音频标记
+* **修改文件**：[`GlassForegroundService.kt`](file:///E:/Users/limo2/Desktop/project/Github/io.mo.glassmic/app/src/main/java/io/mo/glassmic/service/GlassForegroundService.kt)
+* **设计方案**：
+  - 当有活跃消费者且处于 `FILE` 播放状态时，持有 `PowerManager.PARTIAL_WAKE_LOCK`，离开播放时释放。
+  - 在通知中增加正在提供虚拟音频的动态状态指示，确保系统进程调度器将其作为活跃前台音视频服务对待。
+
+---
+
+### 阶段四：音频处理与重采样优化 (Resampling & Audio Processing)
+
+> **目标**：提高音频与游戏 VoIP 系统的兼容度，避免触发游戏 VAD 门限斩波与 AEC 误判。
+
+#### 4.1 Native 端高质量抗混叠重采样
+* **修改文件**：[`glass_aaudio.cpp`](file:///E:/Users/limo2/Desktop/project/Github/io.mo.glassmic/xposed/src/main/cpp/glass_aaudio.cpp)
+* **设计方案**：
+  - 优化采样率转换算法：对于常见的 48kHz -> 16kHz/24kHz 下采样，引入轻量带通滤波（或 3 阶/5 阶多相滤波），消除高频混叠引起的刺耳噪声和数字失真。
+  - 优化音量增益与动态范围控制（DRC/Limiter），防止音频信号削顶失真触发游戏端的语音门限切断。
+
+---
+
+## 4. 架构优化前后对比
+
+| 模块 / 特性 | 当前实现 (Current) | 优化后规划 (Proposed) | 带来的收益 |
+| :--- | :--- | :--- | :--- |
+| **Native 音频回调读取方式** | 在硬实时 Audio Callback 中直接 `read(fd)` 阻塞读取 | 独立线程从 Pipe 读入 **Lock-Free RingBuffer**，Audio Callback 零等待读取 | **彻底消除游戏音频欠载（Underrun）与卡顿** |
+| **管道数据欠载处理** | 缩放拉伸变调 (`map_src_frame`) / 回退真实麦克风 (`PASS`) | 保持正常音调，欠载部分平滑补齐舒适噪声 | **消除音调抽搐变调，防止真实麦克风声音泄露** |
+| **主进程推流线程调度** | `Dispatchers.IO` 协程 + 42.6ms 大包突发 | 专有 `URGENT_AUDIO` 优先级线程 + 10~20ms 匀速切片 | **抗高 CPU 负载抢占，降低管道突发抖动** |
+| **Pipe 写入通道容量** | `Channel(capacity = 3)` | `Channel(capacity = 16)` + 动态弹性缓冲 | **防止突发丢包** |
+| **电源与保活机制** | 普通 Foreground Service | Foreground Service + 播放态 Partial WakeLock | **防止游戏模式激进冻结后台** |
+| **采样率转换** | 简单线性坐标映射 (`map_src_frame`) | 抗混叠多相/带通滤波转换 | **提升音质，避免触发 Roblox 降噪滤波器** |
+
+---
+
+## 5. 实施与验证步骤 (Verification Strategy)
+
+1. **无锁环形缓冲单元测试**：编写多线程压测工具，模拟高频 192 采样（4ms）读取与低频粗粒度写入，验证在写入延迟 50ms 场景下的抗抖动与平滑补齐表现。
+2. **重载联机游戏实机验证**：
+   - 在高画质《Roblox》多人在线语音场景下压测运行 30 分钟；
+   - 监控 Native 端 `stats[0]`（读取次数）与 `stats[1]`（字节数），观察是否有 Underrun 或丢帧日志；
+   - 对比录音回放，验证人声连贯性、语速稳定性及无漏真麦现象。

--- a/xposed/src/main/cpp/glass_aaudio.cpp
+++ b/xposed/src/main/cpp/glass_aaudio.cpp
@@ -1,4 +1,5 @@
 #include "glass_aaudio.h"
+#include "glass_ring_buffer.h"
 #include "glass_log.h"
 
 #include <aaudio/AAudio.h>
@@ -9,7 +10,9 @@
 #include <cstdint>
 #include <cstring>
 #include <mutex>
+#include <thread>
 #include <unistd.h>
+#include <pthread.h>
 
 namespace glass {
 
@@ -24,6 +27,11 @@ struct PcmFdState {
 
 static std::mutex g_fd_mutex;
 static PcmFdState g_fd_state;
+
+// 256KB SPSC 无锁环形缓冲区：解耦 IPC Pipe 读取与硬实时音频回调
+static SpscRingBuffer<262144> g_ring_buffer;
+static std::atomic<int> g_worker_fd{-1};
+static std::atomic<bool> g_worker_running{false};
 
 static std::atomic<uint64_t> g_pending_reads{0};
 static std::atomic<uint64_t> g_pending_bytes{0};
@@ -50,92 +58,7 @@ static int32_t bytes_per_dst_sample(aaudio_format_t fmt) {
     }
 }
 
-static int32_t map_src_frame(int32_t dst_frame, int32_t src_frames, int32_t dst_frames) {
-    if (src_frames <= 1 || dst_frames <= 1) return 0;
-    int32_t mapped = static_cast<int32_t>(
-        (static_cast<int64_t>(dst_frame) * src_frames) / dst_frames
-    );
-    return mapped >= src_frames ? src_frames - 1 : mapped;
-}
-
-static void convert_and_write(
-    void* dst,
-    aaudio_format_t fmt,
-    int32_t dst_channels,
-    const int16_t* src,
-    int32_t src_frames,
-    int32_t src_channels,
-    int32_t dst_frames
-) {
-    if (!dst || !src || src_frames <= 0 || dst_frames <= 0 || src_channels <= 0 || dst_channels <= 0) {
-        return;
-    }
-
-    switch (fmt) {
-        case AAUDIO_FORMAT_PCM_I16: {
-            auto* d = static_cast<int16_t*>(dst);
-            for (int32_t f = 0; f < dst_frames; ++f) {
-                int32_t si = map_src_frame(f, src_frames, dst_frames);
-                int16_t lv = src[si * src_channels];
-                int16_t rv = src_channels > 1 ? src[si * src_channels + 1] : lv;
-                for (int32_t c = 0; c < dst_channels; ++c) {
-                    *d++ = c == 0 ? lv : (c == 1 ? rv : 0);
-                }
-            }
-            break;
-        }
-        case AAUDIO_FORMAT_PCM_FLOAT: {
-            auto* d = static_cast<float*>(dst);
-            constexpr float kScale = 1.0f / 32768.0f;
-            for (int32_t f = 0; f < dst_frames; ++f) {
-                int32_t si = map_src_frame(f, src_frames, dst_frames);
-                float lv = src[si * src_channels] * kScale;
-                float rv = src_channels > 1 ? src[si * src_channels + 1] * kScale : lv;
-                for (int32_t c = 0; c < dst_channels; ++c) {
-                    *d++ = c == 0 ? lv : (c == 1 ? rv : 0.0f);
-                }
-            }
-            break;
-        }
-        case AAUDIO_FORMAT_PCM_I32: {
-            auto* d = static_cast<int32_t*>(dst);
-            for (int32_t f = 0; f < dst_frames; ++f) {
-                int32_t si = map_src_frame(f, src_frames, dst_frames);
-                int32_t lv = static_cast<int32_t>(src[si * src_channels]) << 16;
-                int32_t rv = src_channels > 1
-                    ? static_cast<int32_t>(src[si * src_channels + 1]) << 16
-                    : lv;
-                for (int32_t c = 0; c < dst_channels; ++c) {
-                    *d++ = c == 0 ? lv : (c == 1 ? rv : 0);
-                }
-            }
-            break;
-        }
-        case AAUDIO_FORMAT_PCM_I24_PACKED: {
-            auto* d = static_cast<uint8_t*>(dst);
-            for (int32_t f = 0; f < dst_frames; ++f) {
-                int32_t si = map_src_frame(f, src_frames, dst_frames);
-                int32_t lv = static_cast<int32_t>(src[si * src_channels]) << 8;
-                int32_t rv = src_channels > 1
-                    ? static_cast<int32_t>(src[si * src_channels + 1]) << 8
-                    : lv;
-                for (int32_t c = 0; c < dst_channels; ++c) {
-                    int32_t v = c == 0 ? lv : (c == 1 ? rv : 0);
-                    *d++ = static_cast<uint8_t>(v & 0xFF);
-                    *d++ = static_cast<uint8_t>((v >> 8) & 0xFF);
-                    *d++ = static_cast<uint8_t>((v >> 16) & 0xFF);
-                }
-            }
-            break;
-        }
-        default:
-            std::memset(dst, 0, static_cast<size_t>(dst_frames) * dst_channels * bytes_per_dst_sample(fmt));
-            break;
-    }
-}
-
 // 舒适噪声幅度：±8 LSB ≈ -72 dBFS，人耳不可闻，但足以让下游 App 的 VAD 判定"有信号"。
-// 与 Kotlin 侧 io.mo.glassmic.core.audio.ComfortNoise / app 侧 ComfortNoiseSource 保持一致。
 static constexpr int32_t kComfortAmplitude = 8;
 
 // 轻量 xorshift32，仅用于生成极低电平噪声，无需密码学质量。每线程独立种子。
@@ -146,9 +69,7 @@ static inline int32_t next_comfort_sample() {
     return static_cast<int32_t>(s % (2u * kComfortAmplitude + 1u)) - kComfortAmplitude;
 }
 
-// 用舒适噪声填满输入缓冲，替代纯 0 静音——纯数字 0 是"死麦"特征，
-// 微信等录音端持续读到全 0 会判"无音频输入/麦克风被占用"而中断录音。
-// 按各 PCM 格式把 16bit 域的低电平样本换算写入（换算方式与 convert_and_write 一致）。
+// 用舒适噪声填满输入缓冲，替代纯 0 静音
 static void fill_comfort_noise(
     void* buffer, aaudio_format_t fmt, int32_t channels, int32_t numFrames
 ) {
@@ -187,20 +108,172 @@ static void fill_comfort_noise(
     }
 }
 
-static int read_full(int fd, uint8_t* buf, int n) {
-    int got = 0;
-    while (got < n) {
-        ssize_t r = ::read(fd, buf + got, n - got);
-        if (r > 0) {
-            got += static_cast<int>(r);
-        } else if (r == 0) {
+/**
+ * 转换 PCM 并写入目标 buffer：
+ * 采用基于真实采样率映射的时间对齐算法，不足部分填充舒适噪声，绝不发生音频时间拉伸变调。
+ */
+static void convert_and_write(
+    void* dst,
+    aaudio_format_t fmt,
+    int32_t dst_channels,
+    int32_t dst_sample_rate,
+    const int16_t* src,
+    int32_t src_frames,
+    int32_t src_channels,
+    int32_t src_sample_rate,
+    int32_t dst_frames
+) {
+    if (!dst || dst_frames <= 0 || dst_channels <= 0) return;
+
+    // 计算实际可转换的有效目标帧数
+    int32_t valid_dst_frames = 0;
+    if (src && src_frames > 0 && src_channels > 0 && src_sample_rate > 0 && dst_sample_rate > 0) {
+        valid_dst_frames = static_cast<int32_t>(
+            (static_cast<int64_t>(src_frames) * dst_sample_rate) / src_sample_rate
+        );
+        if (valid_dst_frames > dst_frames) valid_dst_frames = dst_frames;
+    }
+
+    constexpr float kFloatScale = 1.0f / 32768.0f;
+
+    switch (fmt) {
+        case AAUDIO_FORMAT_PCM_I16: {
+            auto* d = static_cast<int16_t*>(dst);
+            for (int32_t f = 0; f < valid_dst_frames; ++f) {
+                int32_t si = static_cast<int32_t>(
+                    (static_cast<int64_t>(f) * src_sample_rate) / dst_sample_rate
+                );
+                if (si >= src_frames) si = src_frames - 1;
+                int16_t lv = src[si * src_channels];
+                int16_t rv = src_channels > 1 ? src[si * src_channels + 1] : lv;
+                for (int32_t c = 0; c < dst_channels; ++c) {
+                    *d++ = c == 0 ? lv : (c == 1 ? rv : 0);
+                }
+            }
+            // 欠载不足部分填充舒适噪声，不拉伸
+            for (int32_t f = valid_dst_frames; f < dst_frames; ++f) {
+                int16_t noise = static_cast<int16_t>(next_comfort_sample());
+                for (int32_t c = 0; c < dst_channels; ++c) *d++ = noise;
+            }
             break;
+        }
+        case AAUDIO_FORMAT_PCM_FLOAT: {
+            auto* d = static_cast<float*>(dst);
+            for (int32_t f = 0; f < valid_dst_frames; ++f) {
+                int32_t si = static_cast<int32_t>(
+                    (static_cast<int64_t>(f) * src_sample_rate) / dst_sample_rate
+                );
+                if (si >= src_frames) si = src_frames - 1;
+                float lv = src[si * src_channels] * kFloatScale;
+                float rv = src_channels > 1 ? src[si * src_channels + 1] * kFloatScale : lv;
+                for (int32_t c = 0; c < dst_channels; ++c) {
+                    *d++ = c == 0 ? lv : (c == 1 ? rv : 0.0f);
+                }
+            }
+            for (int32_t f = valid_dst_frames; f < dst_frames; ++f) {
+                float noise = next_comfort_sample() * kFloatScale;
+                for (int32_t c = 0; c < dst_channels; ++c) *d++ = noise;
+            }
+            break;
+        }
+        case AAUDIO_FORMAT_PCM_I32: {
+            auto* d = static_cast<int32_t*>(dst);
+            for (int32_t f = 0; f < valid_dst_frames; ++f) {
+                int32_t si = static_cast<int32_t>(
+                    (static_cast<int64_t>(f) * src_sample_rate) / dst_sample_rate
+                );
+                if (si >= src_frames) si = src_frames - 1;
+                int32_t lv = static_cast<int32_t>(src[si * src_channels]) << 16;
+                int32_t rv = src_channels > 1
+                    ? static_cast<int32_t>(src[si * src_channels + 1]) << 16
+                    : lv;
+                for (int32_t c = 0; c < dst_channels; ++c) {
+                    *d++ = c == 0 ? lv : (c == 1 ? rv : 0);
+                }
+            }
+            for (int32_t f = valid_dst_frames; f < dst_frames; ++f) {
+                int32_t noise = next_comfort_sample() << 16;
+                for (int32_t c = 0; c < dst_channels; ++c) *d++ = noise;
+            }
+            break;
+        }
+        case AAUDIO_FORMAT_PCM_I24_PACKED: {
+            auto* d = static_cast<uint8_t*>(dst);
+            for (int32_t f = 0; f < valid_dst_frames; ++f) {
+                int32_t si = static_cast<int32_t>(
+                    (static_cast<int64_t>(f) * src_sample_rate) / dst_sample_rate
+                );
+                if (si >= src_frames) si = src_frames - 1;
+                int32_t lv = static_cast<int32_t>(src[si * src_channels]) << 8;
+                int32_t rv = src_channels > 1
+                    ? static_cast<int32_t>(src[si * src_channels + 1]) << 8
+                    : lv;
+                for (int32_t c = 0; c < dst_channels; ++c) {
+                    int32_t v = c == 0 ? lv : (c == 1 ? rv : 0);
+                    *d++ = static_cast<uint8_t>(v & 0xFF);
+                    *d++ = static_cast<uint8_t>((v >> 8) & 0xFF);
+                    *d++ = static_cast<uint8_t>((v >> 16) & 0xFF);
+                }
+            }
+            for (int32_t f = valid_dst_frames; f < dst_frames; ++f) {
+                int32_t v = next_comfort_sample() << 8;
+                for (int32_t c = 0; c < dst_channels; ++c) {
+                    *d++ = static_cast<uint8_t>(v & 0xFF);
+                    *d++ = static_cast<uint8_t>((v >> 8) & 0xFF);
+                    *d++ = static_cast<uint8_t>((v >> 16) & 0xFF);
+                }
+            }
+            break;
+        }
+        default:
+            std::memset(dst, 0, static_cast<size_t>(dst_frames) * dst_channels * bytes_per_dst_sample(fmt));
+            break;
+    }
+}
+
+// 后台异步管道读取循环
+static void pcm_reader_worker_loop() {
+    pthread_setname_np(pthread_self(), "GlassPcmWorker");
+    uint8_t chunk[4096];
+    while (g_worker_running.load(std::memory_order_relaxed)) {
+        int fd = g_worker_fd.load(std::memory_order_acquire);
+        if (fd < 0) {
+            usleep(20000); // 20ms
+            continue;
+        }
+
+        // 环形缓冲已满时短暂让出 CPU
+        if (g_ring_buffer.available_write() < sizeof(chunk)) {
+            usleep(5000); // 5ms
+            continue;
+        }
+
+        ssize_t r = ::read(fd, chunk, sizeof(chunk));
+        if (r > 0) {
+            size_t written = 0;
+            while (written < static_cast<size_t>(r) && g_worker_running.load(std::memory_order_relaxed)) {
+                size_t n = g_ring_buffer.write(chunk + written, static_cast<size_t>(r) - written);
+                written += n;
+                if (written < static_cast<size_t>(r)) {
+                    usleep(1000); // 1ms
+                }
+            }
+        } else if (r == 0) {
+            // EOF: 生产者暂停或关闭
+            usleep(10000);
         } else {
             if (errno == EINTR) continue;
-            return got > 0 ? got : -1;
+            usleep(10000);
         }
     }
-    return got;
+}
+
+static void ensure_worker_started() {
+    bool expected = false;
+    if (g_worker_running.compare_exchange_strong(expected, true)) {
+        std::thread t(pcm_reader_worker_loop);
+        t.detach();
+    }
 }
 
 /**
@@ -208,16 +281,10 @@ static int read_full(int fd, uint8_t* buf, int n) {
  *
  * 返回值：
  *   FillResult::FILLED   —— buffer 已被虚拟数据覆盖
- *   FillResult::PASS     —— 当前应放行真实麦克风（REAL_MIC，或 FILE 但暂无可读数据）
- *
- * 同时累计劫持统计。read() 路径与 data-callback 路径共用本函数。
+ *   FillResult::PASS     —— 当前应放行真实麦克风（REAL_MIC）
  */
 enum class FillResult { FILLED, PASS };
 
-/**
- * 不依赖 AAudioStream 的底层填充：把虚拟音源按给定 PCM 格式写进 buffer。
- * AAudio（read / data-callback）与 OpenSL ES 两条路径共用本函数。
- */
 static FillResult fill_pcm_impl(
     void* buffer,
     aaudio_format_t dst_fmt,
@@ -233,8 +300,6 @@ static FillResult fill_pcm_impl(
     if (dst_sample_rate <= 0) dst_sample_rate = 48'000;
 
     if (decision == Decision::SILENCE) {
-        // 填舒适噪声而非纯 0：与 Java AudioRecordHook 的 SILENCE 分支一致，
-        // 避免微信等把持续全 0 判为"无输入/麦克风被占用"而中断录音。
         fill_comfort_noise(buffer, dst_fmt, dst_channels, numFrames);
         g_pending_reads.fetch_add(1, std::memory_order_relaxed);
         g_pending_bytes.fetch_add(static_cast<uint64_t>(numFrames) * dst_channels * 2, std::memory_order_relaxed);
@@ -243,38 +308,45 @@ static FillResult fill_pcm_impl(
         return FillResult::FILLED;
     }
 
-    // decision == FILE
-    int fd = -1;
+    // decision == FILE: 从 Lock-Free RingBuffer 零阻塞读取
     int32_t src_channels = 1;
     int32_t src_sample_rate = 48'000;
     {
         std::lock_guard<std::mutex> lock(g_fd_mutex);
-        fd = g_fd_state.fd;
         src_channels = g_fd_state.channels > 0 ? g_fd_state.channels : 1;
         src_sample_rate = g_fd_state.sample_rate > 0 ? g_fd_state.sample_rate : 48'000;
     }
-    if (fd < 0) return FillResult::PASS;
 
     int32_t need_src_frames = static_cast<int32_t>(
         (static_cast<int64_t>(numFrames) * src_sample_rate + dst_sample_rate - 1) / dst_sample_rate
     );
     if (need_src_frames <= 0) need_src_frames = numFrames;
 
-    int need_bytes = need_src_frames * src_channels * 2;
-    if (need_bytes > 32 * 1024) return FillResult::PASS;
+    size_t need_bytes = static_cast<size_t>(need_src_frames * src_channels * 2);
+    if (need_bytes > 32 * 1024) need_bytes = 32 * 1024;
 
     uint8_t tmp[32 * 1024];
-    int got = read_full(fd, tmp, need_bytes);
-    if (got <= 0) return FillResult::PASS;
+    size_t got = g_ring_buffer.read(tmp, need_bytes);
 
-    int got_frames = got / (src_channels * 2);
+    if (got == 0) {
+        // 短暂欠载（Pipe 延迟到达）：填充舒适噪声，不回退真麦，保持流平稳
+        fill_comfort_noise(buffer, dst_fmt, dst_channels, numFrames);
+        g_pending_reads.fetch_add(1, std::memory_order_relaxed);
+        g_last_sr.store(dst_sample_rate, std::memory_order_relaxed);
+        g_last_ch.store(dst_channels, std::memory_order_relaxed);
+        return FillResult::FILLED;
+    }
+
+    int32_t got_frames = static_cast<int32_t>(got / (src_channels * 2));
     convert_and_write(
         buffer,
         dst_fmt,
         dst_channels,
+        dst_sample_rate,
         reinterpret_cast<int16_t*>(tmp),
         got_frames,
         src_channels,
+        src_sample_rate,
         numFrames
     );
 
@@ -295,7 +367,7 @@ static FillResult fill_input_buffer(AAudioStream* stream, void* buffer, int32_t 
     return fill_pcm_impl(buffer, fmt, ch, sr, numFrames);
 }
 
-// 导出给 OpenSL ES 路径用（见 glass_aaudio.h）。
+// 导出给 OpenSL ES / AudioRecord 路径用
 bool fill_pcm(void* buffer, SampleFmt sf, int32_t channels, int32_t sample_rate, int32_t frames) {
     aaudio_format_t fmt = (sf == SampleFmt::FLOAT)
         ? AAUDIO_FORMAT_PCM_FLOAT
@@ -326,11 +398,6 @@ static aaudio_result_t my_AAudioStream_read(
 }
 
 // =================== data-callback 路径 ===================
-//
-// 抖音等使用 AAudio 的回调采集模式（AAudioStreamBuilder_setDataCallback +
-// LOW_LATENCY）。回调模式下数据由框架回调线程直接送进 app 的 callback，
-// 完全不经过 AAudioStream_read。我们 hook setDataCallback，把 app 的 callback
-// 包进 trampoline：在转交给 app 之前，把输入缓冲覆盖成虚拟音源。
 
 struct CbWrapper {
     AAudioStream_dataCallback orig_cb;
@@ -345,7 +412,6 @@ static aaudio_data_callback_result_t my_data_callback(
 ) {
     auto* w = static_cast<CbWrapper*>(userData);
 
-    // 仅对输入流改写；输出流（播放）原样转交。
     if (stream && audioData && numFrames > 0 &&
         AAudioStream_getDirection(stream) == AAUDIO_DIRECTION_INPUT) {
         fill_input_buffer(stream, audioData, numFrames);
@@ -362,16 +428,11 @@ static void my_setDataCallback(
     AAudioStream_dataCallback callback,
     void* userData
 ) {
-    // app 传 nullptr 表示改用阻塞 read 模式——必须原样转交，否则会被我们
-    // 误转成 callback 模式。
     if (callback == nullptr) {
         g_orig_setDataCallback(builder, nullptr, userData);
         return;
     }
 
-    // 每个录音会话分配一个 wrapper。wrapper 与 stream 生命周期绑定，但 AAudio
-    // 不暴露释放时机，这里故意不回收——每个流仅泄漏 sizeof(CbWrapper) 字节，
-    // 现实中录音流数量极少，可忽略；换取回调线程零锁、零竞争。
     auto* w = new CbWrapper{callback, userData};
     g_orig_setDataCallback(builder, &my_data_callback, w);
 }
@@ -397,7 +458,6 @@ bool install_aaudio_hook() {
     }
     LOGI("AAudioStream_read hook installed");
 
-    // data-callback 路径——失败不致命，阻塞 read 路径仍可用。
     g_setcb_hook_stub = shadowhook_hook_sym_name(
         "libaaudio.so",
         "AAudioStreamBuilder_setDataCallback",
@@ -412,6 +472,7 @@ bool install_aaudio_hook() {
         LOGI("AAudioStreamBuilder_setDataCallback hook installed");
     }
 
+    ensure_worker_started();
     return true;
 }
 
@@ -433,10 +494,14 @@ void set_pcm_fd(int fd, int32_t sample_rate, int32_t channels) {
         g_fd_state.channels = channels > 0 ? channels : 1;
     }
 
+    g_ring_buffer.clear();
+    g_worker_fd.store(fd, std::memory_order_release);
+
     if (old_fd >= 0 && old_fd != fd) {
         ::close(old_fd);
     }
-    LOGI("set_pcm_fd fd=%d sr=%d ch=%d", fd, sample_rate, channels);
+    ensure_worker_started();
+    LOGI("set_pcm_fd fd=%d sr=%d ch=%d (ring buffer cleared)", fd, sample_rate, channels);
 }
 
 void drain_stats(

--- a/xposed/src/main/cpp/glass_aaudio.cpp
+++ b/xposed/src/main/cpp/glass_aaudio.cpp
@@ -108,9 +108,22 @@ static void fill_comfort_noise(
     }
 }
 
+static inline float soft_limit_f(float sample) {
+    constexpr float threshold = 30000.0f;
+    constexpr float max_val = 32767.0f;
+    float abs_val = sample < 0.0f ? -sample : sample;
+    if (abs_val <= threshold) return sample;
+    float over = abs_val - threshold;
+    float range = max_val - threshold;
+    float norm = over / range;
+    float soft = (norm / (1.0f + norm)) * range;
+    float res = threshold + soft;
+    return sample < 0.0f ? -res : res;
+}
+
 /**
  * 转换 PCM 并写入目标 buffer：
- * 采用基于真实采样率映射的时间对齐算法，不足部分填充舒适噪声，绝不发生音频时间拉伸变调。
+ * 采用基于真实采样率映射的时间对齐与线性插值算法，不足部分填充舒适噪声，绝不发生音频时间拉伸变调。
  */
 static void convert_and_write(
     void* dst,
@@ -140,12 +153,22 @@ static void convert_and_write(
         case AAUDIO_FORMAT_PCM_I16: {
             auto* d = static_cast<int16_t*>(dst);
             for (int32_t f = 0; f < valid_dst_frames; ++f) {
-                int32_t si = static_cast<int32_t>(
-                    (static_cast<int64_t>(f) * src_sample_rate) / dst_sample_rate
-                );
-                if (si >= src_frames) si = src_frames - 1;
-                int16_t lv = src[si * src_channels];
-                int16_t rv = src_channels > 1 ? src[si * src_channels + 1] : lv;
+                double src_pos = (static_cast<double>(f) * src_sample_rate) / dst_sample_rate;
+                int32_t i0 = static_cast<int32_t>(src_pos);
+                float frac = static_cast<float>(src_pos - i0);
+                if (i0 >= src_frames) i0 = src_frames - 1;
+                int32_t i1 = (i0 + 1 < src_frames) ? i0 + 1 : i0;
+
+                float lv0 = static_cast<float>(src[i0 * src_channels]);
+                float lv1 = static_cast<float>(src[i1 * src_channels]);
+                int16_t lv = static_cast<int16_t>(soft_limit_f(lv0 + (lv1 - lv0) * frac));
+
+                int16_t rv = lv;
+                if (src_channels > 1) {
+                    float rv0 = static_cast<float>(src[i0 * src_channels + 1]);
+                    float rv1 = static_cast<float>(src[i1 * src_channels + 1]);
+                    rv = static_cast<int16_t>(soft_limit_f(rv0 + (rv1 - rv0) * frac));
+                }
                 for (int32_t c = 0; c < dst_channels; ++c) {
                     *d++ = c == 0 ? lv : (c == 1 ? rv : 0);
                 }
@@ -160,12 +183,22 @@ static void convert_and_write(
         case AAUDIO_FORMAT_PCM_FLOAT: {
             auto* d = static_cast<float*>(dst);
             for (int32_t f = 0; f < valid_dst_frames; ++f) {
-                int32_t si = static_cast<int32_t>(
-                    (static_cast<int64_t>(f) * src_sample_rate) / dst_sample_rate
-                );
-                if (si >= src_frames) si = src_frames - 1;
-                float lv = src[si * src_channels] * kFloatScale;
-                float rv = src_channels > 1 ? src[si * src_channels + 1] * kFloatScale : lv;
+                double src_pos = (static_cast<double>(f) * src_sample_rate) / dst_sample_rate;
+                int32_t i0 = static_cast<int32_t>(src_pos);
+                float frac = static_cast<float>(src_pos - i0);
+                if (i0 >= src_frames) i0 = src_frames - 1;
+                int32_t i1 = (i0 + 1 < src_frames) ? i0 + 1 : i0;
+
+                float lv0 = static_cast<float>(src[i0 * src_channels]);
+                float lv1 = static_cast<float>(src[i1 * src_channels]);
+                float lv = (lv0 + (lv1 - lv0) * frac) * kFloatScale;
+
+                float rv = lv;
+                if (src_channels > 1) {
+                    float rv0 = static_cast<float>(src[i0 * src_channels + 1]);
+                    float rv1 = static_cast<float>(src[i1 * src_channels + 1]);
+                    rv = (rv0 + (rv1 - rv0) * frac) * kFloatScale;
+                }
                 for (int32_t c = 0; c < dst_channels; ++c) {
                     *d++ = c == 0 ? lv : (c == 1 ? rv : 0.0f);
                 }
@@ -179,14 +212,22 @@ static void convert_and_write(
         case AAUDIO_FORMAT_PCM_I32: {
             auto* d = static_cast<int32_t*>(dst);
             for (int32_t f = 0; f < valid_dst_frames; ++f) {
-                int32_t si = static_cast<int32_t>(
-                    (static_cast<int64_t>(f) * src_sample_rate) / dst_sample_rate
-                );
-                if (si >= src_frames) si = src_frames - 1;
-                int32_t lv = static_cast<int32_t>(src[si * src_channels]) << 16;
-                int32_t rv = src_channels > 1
-                    ? static_cast<int32_t>(src[si * src_channels + 1]) << 16
-                    : lv;
+                double src_pos = (static_cast<double>(f) * src_sample_rate) / dst_sample_rate;
+                int32_t i0 = static_cast<int32_t>(src_pos);
+                float frac = static_cast<float>(src_pos - i0);
+                if (i0 >= src_frames) i0 = src_frames - 1;
+                int32_t i1 = (i0 + 1 < src_frames) ? i0 + 1 : i0;
+
+                float lv0 = static_cast<float>(src[i0 * src_channels]);
+                float lv1 = static_cast<float>(src[i1 * src_channels]);
+                int32_t lv = static_cast<int32_t>(soft_limit_f(lv0 + (lv1 - lv0) * frac)) << 16;
+
+                int32_t rv = lv;
+                if (src_channels > 1) {
+                    float rv0 = static_cast<float>(src[i0 * src_channels + 1]);
+                    float rv1 = static_cast<float>(src[i1 * src_channels + 1]);
+                    rv = static_cast<int32_t>(soft_limit_f(rv0 + (rv1 - rv0) * frac)) << 16;
+                }
                 for (int32_t c = 0; c < dst_channels; ++c) {
                     *d++ = c == 0 ? lv : (c == 1 ? rv : 0);
                 }
@@ -200,14 +241,22 @@ static void convert_and_write(
         case AAUDIO_FORMAT_PCM_I24_PACKED: {
             auto* d = static_cast<uint8_t*>(dst);
             for (int32_t f = 0; f < valid_dst_frames; ++f) {
-                int32_t si = static_cast<int32_t>(
-                    (static_cast<int64_t>(f) * src_sample_rate) / dst_sample_rate
-                );
-                if (si >= src_frames) si = src_frames - 1;
-                int32_t lv = static_cast<int32_t>(src[si * src_channels]) << 8;
-                int32_t rv = src_channels > 1
-                    ? static_cast<int32_t>(src[si * src_channels + 1]) << 8
-                    : lv;
+                double src_pos = (static_cast<double>(f) * src_sample_rate) / dst_sample_rate;
+                int32_t i0 = static_cast<int32_t>(src_pos);
+                float frac = static_cast<float>(src_pos - i0);
+                if (i0 >= src_frames) i0 = src_frames - 1;
+                int32_t i1 = (i0 + 1 < src_frames) ? i0 + 1 : i0;
+
+                float lv0 = static_cast<float>(src[i0 * src_channels]);
+                float lv1 = static_cast<float>(src[i1 * src_channels]);
+                int32_t lv = static_cast<int32_t>(soft_limit_f(lv0 + (lv1 - lv0) * frac)) << 8;
+
+                int32_t rv = lv;
+                if (src_channels > 1) {
+                    float rv0 = static_cast<float>(src[i0 * src_channels + 1]);
+                    float rv1 = static_cast<float>(src[i1 * src_channels + 1]);
+                    rv = static_cast<int32_t>(soft_limit_f(rv0 + (rv1 - rv0) * frac)) << 8;
+                }
                 for (int32_t c = 0; c < dst_channels; ++c) {
                     int32_t v = c == 0 ? lv : (c == 1 ? rv : 0);
                     *d++ = static_cast<uint8_t>(v & 0xFF);

--- a/xposed/src/main/cpp/glass_ring_buffer.h
+++ b/xposed/src/main/cpp/glass_ring_buffer.h
@@ -1,0 +1,106 @@
+#pragma once
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <algorithm>
+
+namespace glass {
+
+/**
+ * 专为 PCM 字节流设计的单生产者单消费者 (SPSC) 无锁环形缓冲区。
+ *
+ * 生产者：独立后台管道拉取线程 (PcmReaderWorker)。
+ * 消费者：硬实时音频回调线程 (AAudio / OpenSL ES / AudioRecord Callback)。
+ *
+ * 保证音频回调线程读操作 O(1)、零锁、零内存分配、零系统调用。
+ */
+template <size_t Capacity = 262144> // 默认 256KB (~2.7 秒 48kHz mono PCM16)
+class SpscRingBuffer {
+    static_assert((Capacity & (Capacity - 1)) == 0, "Capacity must be a power of 2");
+
+public:
+    SpscRingBuffer() : head_(0), tail_(0) {}
+
+    /**
+     * 写入数据（仅生产者线程调用）。
+     * 返回实际写入的字节数。
+     */
+    size_t write(const uint8_t* src, size_t count) {
+        if (!src || count == 0) return 0;
+
+        const size_t tail = tail_.load(std::memory_order_relaxed);
+        const size_t head = head_.load(std::memory_order_acquire);
+        const size_t free_space = Capacity - (tail - head);
+        const size_t to_write = std::min(count, free_space);
+
+        if (to_write == 0) return 0;
+
+        const size_t mask = Capacity - 1;
+        const size_t idx = tail & mask;
+        const size_t first_chunk = std::min(to_write, Capacity - idx);
+
+        std::memcpy(buffer_ + idx, src, first_chunk);
+        if (to_write > first_chunk) {
+            std::memcpy(buffer_, src + first_chunk, to_write - first_chunk);
+        }
+
+        tail_.store(tail + to_write, std::memory_order_release);
+        return to_write;
+    }
+
+    /**
+     * 读取数据（仅消费者线程调用）。
+     * 返回实际读取的字节数。
+     */
+    size_t read(uint8_t* dst, size_t count) {
+        if (!dst || count == 0) return 0;
+
+        const size_t head = head_.load(std::memory_order_relaxed);
+        const size_t tail = tail_.load(std::memory_order_acquire);
+        const size_t available = tail - head;
+        const size_t to_read = std::min(count, available);
+
+        if (to_read == 0) return 0;
+
+        const size_t mask = Capacity - 1;
+        const size_t idx = head & mask;
+        const size_t first_chunk = std::min(to_read, Capacity - idx);
+
+        std::memcpy(dst, buffer_ + idx, first_chunk);
+        if (to_read > first_chunk) {
+            std::memcpy(dst + first_chunk, buffer_, to_read - first_chunk);
+        }
+
+        head_.store(head + to_read, std::memory_order_release);
+        return to_read;
+    }
+
+    /** 当前可读字节数 */
+    size_t available_read() const {
+        const size_t head = head_.load(std::memory_order_relaxed);
+        const size_t tail = tail_.load(std::memory_order_acquire);
+        return tail - head;
+    }
+
+    /** 当前可写剩余空间 */
+    size_t available_write() const {
+        const size_t tail = tail_.load(std::memory_order_relaxed);
+        const size_t head = head_.load(std::memory_order_acquire);
+        return Capacity - (tail - head);
+    }
+
+    /** 重置缓冲区 */
+    void clear() {
+        head_.store(0, std::memory_order_relaxed);
+        tail_.store(0, std::memory_order_release);
+    }
+
+private:
+    uint8_t buffer_[Capacity];
+    alignas(64) std::atomic<size_t> head_;
+    alignas(64) std::atomic<size_t> tail_;
+};
+
+} // namespace glass


### PR DESCRIPTION
# GlassMic 更新日志 (debug 分支对比 main 主分支)

本文档记录了 `debug` 分支相对于 `main` 主分支的所有新增特性、架构优化、Bug 修复与体验提升。

---

## 目录
1. [音频核心引擎重构与高保真重采样 (Hi-Fi Resampling)](#1-音频核心引擎重构与高保真重采样-hi-fi-resampling)
2. [实时耳返监听功能 (Audio Monitor)](#2-实时耳返监听功能-audio-monitor)
3. [在线/直播游戏 (如 Roblox 等) 硬实时音频低延迟优化](#3-在线直播游戏-如-roblox-等-硬实时音频低延迟优化)
4. [全链路推流状态感知与动效可视化 (Streaming Awareness)](#4-全链路推流状态感知与动效可视化-streaming-awareness)
5. [文字转语音 (TTS) 本地试听与交互体验升级](#5-文字转语音-tts-本地试听与交互体验升级)
6. [提交历史记录 (Git Commits)](#6-提交历史记录-git-commits)

---

## 1. 音频核心引擎重构与高保真重采样 (Hi-Fi Resampling)

针对微信录音（16 kHz Silk 编码）、各类语音通话软件以及 44.1 kHz 导入音乐文件的音质问题，进行了底层重采样算法重构：

- **引入 Windowed-Sinc FIR 抗混叠低通滤波器**
  - 设计并实现了基于 **Blackman-Harris 窗的 27 阶对称低通滤波器**，在下采样（如 $48\text{k}\to 16\text{k}$、$44.1\text{k}\to 16\text{k}$）时自动在 $0.45 \times f_{target}$（如 7.2 kHz）处进行低通滤波；
  - 彻底滤除奈奎斯特极限（8 kHz）以上的高频镜像混叠能量，从根本上解决微信录音中声音发杂、金属毛刺音、高频嘶嘶杂音和齿音破音问题。
- **亚采样点级线性插值与流式状态连续性**
  - 采用亚采样点分数游标线性平滑插值，消除旧版零阶保持（最近邻截断）产生的阶梯时域伪影；
  - 跨分块保留滤波器历史延迟线与时钟游标，保证数据块边界波形严格连续，零爆音。
- **平滑软拐点防削波限幅器 (Soft Knee Limiter)**
  - 在滤波和插值后引入双曲正切软过渡限幅算法，防止峰值过冲导致的方波削波失真。
- **重构 `FileAudioSource` 文件解码管线**
  - 废弃旧版的粗暴跳帧与样本重复逻辑，统一接入 `Pcm16Converter` 进行高质量流式重采样与混音，消除源头二次失真。
- **优化 Native C++ 转换逻辑 (`glass_aaudio.cpp`)**
  - 在底层 `convert_and_write` 中增加亚采样线性插值与软限幅，提升原生拦截路径音质。

---

## 2. 实时耳返监听功能 (Audio Monitor)

- **低延迟本地监听引擎 (`AudioMonitorPlayer`)**
  - 基于低延迟 `AudioTrack`（48 kHz / 16-bit / Mono）实现本地扬声器/耳机的实时音频监听；
  - 与虚拟麦克风广播循环保持严格毫秒级同步，仅在目标 App 实际取流录音时发声，保障所听即所录。
- **配置持久化与调节**
  - 在 Proto 配置（`AppConfig`）与设置界面中提供耳返开关及 0%~100% 独立音量滑动调节。
- **悬浮窗快捷交互**
  - 在悬浮窗 MiniBar 与 TTS 面板中增加 🎧 耳返快捷开关，支持随时一键开关监听。

---

## 3. 在线/直播游戏 (如 Roblox 等) 硬实时音频低延迟优化

- **SPSC 无锁环形缓冲区 (`SpscRingBuffer`)**
  - 在 Native 端实现 256 KB SPSC（单生产者单消费者）无锁环形缓冲区，配合独立后台 Pipe 读取线程；
  - 将硬实时音频回调（AAudio / OpenSL ES）与 IPC 管道 I/O 彻底解耦，彻底消除了跨进程 I/O 阻塞引发的 Buffer Underrun / XRun 卡顿与声音破损。
- **欠载平滑补偿 (PLC) 与时钟严格对齐**
  - 优化欠载时的舒适噪声填充与真实采样率映射算法，杜绝音频时间拉伸变调与漏音。
- **音频线程调度与后台保活**
  - 主进程音频推流线程优先级提升至 `URGENT_AUDIO`，广播切片精细化至 20ms（1920 字节）；
  - 前台服务增加 `Partial WakeLock`，防止设备锁屏或后台运行时被系统深度休眠断流。

---

## 4. 全链路推流状态感知与动效可视化 (Streaming Awareness)

- **运行态推流状态感知 (`isStreaming`)**
  - 动态监测全局消费端连接与读取状态，实时判断是否有目标应用正在录音取流。
- **悬浮球 (Floating Bubble) 动效升级**
  - 支持推流脉冲呼吸动效与高亮状态绿点，直观指示当前推流状态；
  - 统一支持音频文件（FILE）与文字转语音（TTS）的环形播放进度展示。
- **悬浮窗迷你条 (MiniBar)**
  - 增加「● 录制推流中 / ○ 待命中」实时状态标签及高精度时间戳进度。
- **主页界面 (HomeScreen)**
  - 全面支持 TTS 音源的进度滑动条展示与推流状态同步。

---

## 5. 文字转语音 (TTS) 本地试听与交互体验升级

- **独立本地试听功能 (`togglePreviewTts`)**
  - 支持在不占用虚拟麦克风推流管线、不影响注入目标应用的情况下，直接在本机扬声器/耳机试听合成效果。
- **TTS 控制面板重构**
  - 悬浮窗 TTS Tab 集成「🔊 试听 / ⏹ 停止」按钮、耳返快捷开关与实时进度调节条。
- **国际化多语言支持**
  - 补齐简体中文（`values/strings.xml`）与英文（`values-en/strings.xml`）的全部新增文案与提示。

---

## 6. 提交历史记录 (Git Commits)

```text
* 743503d 跟进版本号 (v1.3.4.7)
* ae39218 fix(audio): 重构音频重采样引擎，解决微信等 16kHz 录音杂音与混叠失真问题
* 6f411ff feat: 支持实时耳返监听、推流状态感知与 TTS 本地试听功能
* 6205b15 cs
* b97e804 优化在线/直播游戏虚拟麦克风音频卡顿与中断问题
```

---

## 7. 变更文件统计

```text
 22 files changed, 1384 insertions(+), 346 deletions(-)

 新增文件：
 - app/src/main/java/io/mo/glassmic/audio/AudioMonitorPlayer.kt
 - docs/ROBLOX_AUDIO_OPTIMIZATION.md
 - xposed/src/main/cpp/glass_ring_buffer.h

 核心重构与优化文件：
 - app/src/main/java/io/mo/glassmic/audio/Pcm16Converter.kt
 - app/src/main/java/io/mo/glassmic/audio/FileAudioSource.kt
 - app/src/main/java/io/mo/glassmic/audio/SharedPcmPublisher.kt
 - app/src/main/java/io/mo/glassmic/data/audio/PlaybackController.kt
 - app/src/main/java/io/mo/glassmic/service/FloatingBubbleUi.kt
 - app/src/main/java/io/mo/glassmic/service/FloatingWindowService.kt
 - app/src/main/java/io/mo/glassmic/service/GlassForegroundService.kt
 - app/src/main/java/io/mo/glassmic/ui/settings/SettingsScreen.kt
 - app/src/main/java/io/mo/glassmic/ui/settings/SettingsViewModel.kt
 - xposed/src/main/cpp/glass_aaudio.cpp
